### PR TITLE
Add static library support (using 'make static').

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ endif
 
 
 PROG     := AdapterRemoval
-OBJS     := $(BDIR)/adapterset.o \
+LIBNAME  := libadapterremoval
+LIBOBJS  := $(BDIR)/adapterset.o \
             $(BDIR)/alignment.o \
             $(BDIR)/argparse.o \
             $(BDIR)/debug.o \
@@ -86,7 +87,6 @@ OBJS     := $(BDIR)/adapterset.o \
             $(BDIR)/fastq_enc.o \
             $(BDIR)/fastq_io.o \
             $(BDIR)/linereader.o \
-            $(BDIR)/main.o \
             $(BDIR)/main_adapter_id.o \
             $(BDIR)/main_adapter_rm.o \
             $(BDIR)/scheduler.o \
@@ -94,11 +94,11 @@ OBJS     := $(BDIR)/adapterset.o \
             $(BDIR)/threads.o \
             $(BDIR)/timer.o \
             $(BDIR)/userconfig.o
-
+OBJS     := ${LIBOBJS} $(BDIR)/main.o
 DFILES   := $(OBJS:.o=.deps)
 
 
-.PHONY: all install clean test clean_tests
+.PHONY: all install clean test clean_tests static
 
 all: build/$(PROG) build/$(PROG).1
 
@@ -114,6 +114,8 @@ install:
 	$(QUIET) mv -f build/$(PROG) /usr/local/bin/
 	$(QUIET) mv -f build/$(PROG).1 /usr/share/man/man1/
 
+static: build/$(LIBNAME).a
+
 # Object files
 $(BDIR)/%.o: src/%.cc
 	@echo $(COLOR_CYAN)"Building '$@' from '$<'"$(COLOR_END)
@@ -125,6 +127,11 @@ $(BDIR)/%.o: src/%.cc
 build/$(PROG): $(OBJS)
 	@echo $(COLOR_GREEN)"Linking executable '$@'"$(COLOR_END)
 	$(QUIET) $(CXX) $(CXXFLAGS) $^ ${LIBRARIES} -o $@
+
+# Static library
+build/$(LIBNAME).a: $(LIBOBJS)
+	@echo $(COLOR_GREEN)"Linking static library '$@'.a"$(COLOR_END)
+	$(AR) rcs build/$(LIBNAME).a $(LIBOBJS)
 
 build/%.1: %.pod
 	@echo $(COLOR_GREEN)"Constructing man-page '$@' from '$<'"$(COLOR_END)
@@ -194,8 +201,9 @@ $(TEST_DIR)/gtest%.o: $(GTEST_DIR)/src/gtest%.cc
 
 $(GTEST_DIR)/src/gtest%.cc:
 	@echo $(COLOR_YELLOW)"To run tests, first download and unpack GoogleTest 1.7.0 in this folder:"$(COLOR_END)
-	@echo $(COLOR_YELLOW)"  $$ wget https://googletest.googlecode.com/files/gtest-1.7.0.zip"$(COLOR_END)
+	@echo $(COLOR_YELLOW)"  $$ wget https://github.com/google/googletest/archive/release-1.7.0.zip -O gtest-1.7.0.zip"$(COLOR_END)
 	@echo $(COLOR_YELLOW)"  $$ unzip gtest-1.7.0.zip"$(COLOR_END)
+	@echo $(COLOR_YELLOW)"  $$ mv googletest-release-1.7.0 gtest-1.7.0
 	@exit 1
 
 # Automatic header dependencies for tests

--- a/include/ar/adapterremoval.h
+++ b/include/ar/adapterremoval.h
@@ -1,0 +1,23 @@
+#ifndef AR_ADAPTERREMOVAL_H
+#define AR_ADAPTERREMOVAL_H
+
+#include "../../src/adapterset.h"
+#include "../../src/alignment.h"
+#include "../../src/argparse.h"
+#include "../../src/commontypes.h"
+#include "../../src/debug.h"
+#include "../../src/demultiplex.h"
+#include "../../src/fastq_enc.h"
+#include "../../src/fastq.h"
+#include "../../src/fastq_io.h"
+#include "../../src/linereader.h"
+#include "../../src/main.h"
+#include "../../src/scheduler.h"
+#include "../../src/statistics.h"
+#include "../../src/strutils.h"
+#include "../../src/threads.h"
+#include "../../src/timer.h"
+#include "../../src/userconfig.h"
+#include "../../src/vecutils.h"
+
+#endif // AR_ADAPTERREMOVAL_H

--- a/src/adapterset.cc
+++ b/src/adapterset.cc
@@ -31,6 +31,8 @@
 #include "linereader.h"
 #include "strutils.h"
 
+namespace ar
+{
 
 typedef std::pair<std::string, fastq_vec> named_fastq_row;
 typedef std::vector<named_fastq_row> fastq_table;
@@ -452,3 +454,5 @@ const std::string& adapter_set::get_sample_name(size_t nth) const
 {
     return m_samples.at(nth);
 }
+
+} // namespace ar

--- a/src/adapterset.h
+++ b/src/adapterset.h
@@ -28,6 +28,8 @@
 #include "commontypes.h"
 #include "fastq.h"
 
+namespace ar
+{
 
 /**
  * Class for reading sets of adapters and barcodes, and for generating
@@ -99,5 +101,6 @@ private:
     fastq_pair_vec m_adapters;
 };
 
+} // namespace ar
 
 #endif

--- a/src/alignment.cc
+++ b/src/alignment.cc
@@ -35,6 +35,8 @@
 #include "debug.h"
 #include "fastq.h"
 
+namespace ar
+{
 
 #if defined(__SSE__) && defined(__SSE2__)
 #include <xmmintrin.h>
@@ -462,3 +464,5 @@ bool extract_adapter_sequences(const alignment_info& alignment,
 
     return read1.sequence().length() || read2.sequence().length();
 }
+
+} // namespace ar

--- a/src/alignment.h
+++ b/src/alignment.h
@@ -28,6 +28,8 @@
 
 #include "fastq.h"
 
+namespace ar
+{
 
 /**
  * Summarizes an alignment.
@@ -202,5 +204,7 @@ fastq collapse_paired_ended_sequences(const alignment_info& alignment,
 bool extract_adapter_sequences(const alignment_info& alignment,
                                fastq& pcr1,
                                fastq& pcr2);
+
+} // namespace ar
 
 #endif

--- a/src/argparse.cc
+++ b/src/argparse.cc
@@ -36,6 +36,8 @@
 #include "strutils.h"
 
 
+namespace ar
+{
 namespace argparse
 {
 
@@ -494,4 +496,5 @@ std::string floaty_knob::to_str() const
     return stream.str();
 }
 
-}
+} // namespace argparse
+} // namespace ar

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -30,7 +30,8 @@
 
 #include "commontypes.h"
 
-
+namespace ar
+{
 namespace argparse
 {
 
@@ -365,9 +366,7 @@ private:
     double* m_ptr;
 };
 
-
-
-
-}
+} // namespace argparse
+} // namespace ar
 
 #endif

--- a/src/commontypes.h
+++ b/src/commontypes.h
@@ -28,6 +28,9 @@
 #include <string>
 #include <vector>
 
+namespace ar
+{
+
 class fastq;
 
 typedef std::vector<std::string> string_vec;
@@ -98,5 +101,6 @@ enum analyses_id
     ai_write_discarded = 26
 };
 
+} // namespace ar
 
 #endif

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -27,6 +27,8 @@
 #include <iostream>
 #include <sstream>
 
+namespace ar
+{
 
 #ifdef AR_TEST_BUILD
 assert_failed::assert_failed(const std::string& what)
@@ -63,3 +65,5 @@ void debug_raise_assert(const char* filename, size_t lineno, const char* what)
     std::abort();
 #endif
 }
+
+} // namespace ar

--- a/src/debug.h
+++ b/src/debug.h
@@ -27,6 +27,8 @@
 #include <stdexcept>
 #include <string>
 
+namespace ar
+{
 
 #ifdef AR_TEST_BUILD
 /** Exception replaining 'abort' calls when running unit-tests. */
@@ -70,5 +72,6 @@ void debug_raise_assert(const char* filename, size_t lineno,
 #define AR_DEBUG_FAIL(msg) \
     debug_raise_assert(__FILE__, __LINE__, msg)
 
+} // namespace ar
 
 #endif

--- a/src/demultiplex.cc
+++ b/src/demultiplex.cc
@@ -31,6 +31,8 @@
 #include "userconfig.h"
 #include "strutils.h"
 
+namespace ar
+{
 
 typedef std::vector<unsigned> int_vec;
 typedef demux_node_vec::iterator node_vec_iter;
@@ -477,3 +479,5 @@ chunk_vec demultiplex_pe_reads::process(analytical_chunk* chunk)
 
     return flush_cache(read_chunk->eof);
 }
+
+} // namespace ar

--- a/src/demultiplex.h
+++ b/src/demultiplex.h
@@ -29,6 +29,8 @@
 #include "scheduler.h"
 #include "statistics.h"
 
+namespace ar
+{
 
 class userconfig;
 class fastq_read_chunk;
@@ -134,5 +136,7 @@ public:
      */
     chunk_vec process(analytical_chunk* chunk);
 };
+
+} // namespace ar
 
 #endif

--- a/src/fastq.cc
+++ b/src/fastq.cc
@@ -30,6 +30,8 @@
 #include "fastq.h"
 #include "linereader.h"
 
+namespace ar
+{
 
 struct mate_info
 {
@@ -336,3 +338,5 @@ void fastq::process_record(const fastq_encoding& encoding)
     clean_sequence(m_sequence);
     encoding.decode_string(m_qualities.begin(), m_qualities.end());
 }
+
+} // namespace ar

--- a/src/fastq.h
+++ b/src/fastq.h
@@ -30,6 +30,8 @@
 #include "commontypes.h"
 #include "fastq_enc.h"
 
+namespace ar
+{
 
 class line_reader_base;
 
@@ -222,5 +224,7 @@ inline const std::string& fastq::qualities() const
 {
     return m_qualities;
 }
+
+} // namespace ar
 
 #endif

--- a/src/fastq_enc.cc
+++ b/src/fastq_enc.cc
@@ -30,6 +30,8 @@
 
 #include "fastq_enc.h"
 
+namespace ar
+{
 
 ///////////////////////////////////////////////////////////////////////////////
 // fastq_error
@@ -311,3 +313,5 @@ std::string fastq_encoding_solexa::name() const
 {
     return "Solexa";
 }
+
+} // namespace ar

--- a/src/fastq_enc.h
+++ b/src/fastq_enc.h
@@ -27,6 +27,8 @@
 
 #include <string>
 
+namespace ar
+{
 
 //! Offset used by Phred+33 and SAM encodings
 const int PHRED_OFFSET_33 = '!';
@@ -140,5 +142,6 @@ static const fastq_encoding FASTQ_ENCODING_64(PHRED_OFFSET_64);
 static const fastq_encoding FASTQ_ENCODING_SAM(PHRED_OFFSET_33, MAX_PHRED_SCORE);
 static const fastq_encoding_solexa FASTQ_ENCODING_SOLEXA;
 
+} // namespace ar
 
 #endif

--- a/src/fastq_io.cc
+++ b/src/fastq_io.cc
@@ -30,6 +30,8 @@
 #include "fastq_io.h"
 #include "userconfig.h"
 
+namespace ar
+{
 
 typedef std::auto_ptr<fastq_read_chunk> chunk_ptr;
 
@@ -570,3 +572,4 @@ void write_paired_fastq::finalize()
     }
 }
 
+} // namespace ar

--- a/src/fastq_io.h
+++ b/src/fastq_io.h
@@ -41,6 +41,8 @@
 #include "linereader.h"
 #include "strutils.h"
 
+namespace ar
+{
 
 class userconfig;
 
@@ -299,5 +301,6 @@ private:
     std::ofstream m_output;
 };
 
+} // namespace ar
 
 #endif

--- a/src/linereader.cc
+++ b/src/linereader.cc
@@ -31,6 +31,9 @@
 #include "linereader.h"
 #include "threads.h"
 
+namespace ar
+{
+
 //! Size of compressed and uncompressed buffers.
 const int BUF_SIZE = 10 * BUFSIZ;
 
@@ -513,3 +516,5 @@ void line_reader::close_buffers_bzip2()
     }
 #endif
 }
+
+} // namespace ar

--- a/src/linereader.h
+++ b/src/linereader.h
@@ -35,6 +35,8 @@
 #include <bzlib.h>
 #endif
 
+namespace ar
+{
 
 /** Represents errors during basic IO. */
 class io_error : public std::ios_base::failure
@@ -180,5 +182,6 @@ inline line_reader_base::~line_reader_base()
 {
 }
 
+} // namespace ar
 
 #endif

--- a/src/main.cc
+++ b/src/main.cc
@@ -29,15 +29,20 @@
 #include "main.h"
 #include "userconfig.h"
 
+namespace ar
+{
 
 // See main_adapter_rm.cc
 int remove_adapter_sequences(const userconfig& config);
 // See main_adapter_id.cc
 int identify_adapter_sequences(const userconfig& config);
 
+} // namespace ar
+
 
 int main(int argc, char *argv[])
 {
+    using namespace ar;
     std::ios_base::sync_with_stdio(false);
 
     userconfig config(NAME, VERSION, HELPTEXT);
@@ -45,7 +50,7 @@ int main(int argc, char *argv[])
     if (result == argparse::pr_error) {
         return 1;
     } else if (result == argparse::pr_exit) {
-        // --version, --help, or simular used.
+        // --version, --help, or similar used.
         return 0;
     }
 
@@ -61,3 +66,4 @@ int main(int argc, char *argv[])
 
     return 1;
 }
+

--- a/src/main.h
+++ b/src/main.h
@@ -27,6 +27,9 @@
 
 #include <string>
 
+namespace ar
+{
+
 const std::string NAME = "AdapterRemoval";
 const std::string VERSION = "ver. 2.1.3";
 const std::string HELPTEXT = \
@@ -40,5 +43,7 @@ const std::string HELPTEXT = \
     "    S. Lindgreen (2012): AdapterRemoval: Easy Cleaning of Next\n"
     "    Generation Sequencing Reads, BMC Research Notes, 5:337,\n"
     "    URL: http://www.biomedcentral.com/1756-0500/5/337/\n";
+
+} // namespace ar
 
 #endif

--- a/src/main_adapter_id.cc
+++ b/src/main_adapter_id.cc
@@ -38,6 +38,8 @@
 #include "timer.h"
 #include "userconfig.h"
 
+namespace ar
+{
 
 ///////////////////////////////////////////////////////////////////////////////
 // KMer related functions and constants
@@ -484,3 +486,5 @@ int identify_adapter_sequences(const userconfig& config)
 
     return 0;
 }
+
+} // namespace ar

--- a/src/main_adapter_rm.cc
+++ b/src/main_adapter_rm.cc
@@ -40,6 +40,8 @@
 #include "strutils.h"
 #include "userconfig.h"
 
+namespace ar
+{
 
 typedef std::auto_ptr<fastq_output_chunk> output_chunk_ptr;
 
@@ -766,3 +768,5 @@ int remove_adapter_sequences(const userconfig& config)
 
     return 0;
 }
+
+} // namespace ar

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -34,6 +34,8 @@
 #include "scheduler.h"
 #include "strutils.h"
 
+namespace ar
+{
 
 ///////////////////////////////////////////////////////////////////////////////
 // exceptions
@@ -577,4 +579,4 @@ bool scheduler::join_threads()
     return join_result;
 }
 
-
+} // namespace ar

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -31,6 +31,8 @@
 
 #include "threads.h"
 
+namespace ar
+{
 
 struct data_chunk;
 struct scheduler_step;
@@ -354,5 +356,7 @@ inline bool analytical_step::file_io() const
 {
     return m_file_io;
 }
+
+} // namespace ar
 
 #endif

--- a/src/statistics.h
+++ b/src/statistics.h
@@ -30,6 +30,8 @@
 
 #include "vecutils.h"
 
+namespace ar
+{
 
 /** Object used to collect summary statistics for trimming and other tasks. */
 struct statistics
@@ -146,5 +148,6 @@ struct demux_statistics
     size_t ambiguous;
 };
 
+} // namespace ar
 
 #endif

--- a/src/strutils.cc
+++ b/src/strutils.cc
@@ -23,6 +23,8 @@
 \*************************************************************************/
 #include "strutils.h"
 
+namespace ar
+{
 
 std::string toupper(const std::string& str)
 {
@@ -199,3 +201,5 @@ std::string cli_formatter::fmt(const std::string& prefix, const std::string& val
 
     return prefix + value;
 }
+
+} // namespace ar

--- a/src/strutils.h
+++ b/src/strutils.h
@@ -28,6 +28,8 @@
 #include <sstream>
 #include <iomanip>
 
+namespace ar
+{
 
 const size_t DEFAULT_MAX_COLUMNS = 60;
 const size_t DEFAULT_INDENTATION = 4;
@@ -100,5 +102,7 @@ private:
     //! The number of spaces to indent each line (see also m_indent_first_line)
     size_t m_indentation;
 };
+
+} // namespace ar
 
 #endif

--- a/src/threads.cc
+++ b/src/threads.cc
@@ -33,6 +33,9 @@
 
 #include <ctime>
 
+namespace ar
+{
+
 ///////////////////////////////////////////////////////////////////////////////
 // exceptions
 
@@ -343,3 +346,5 @@ size_t atomic_counter::decrement()
 
     return --m_count;
 }
+
+} // namespace ar

--- a/src/threads.h
+++ b/src/threads.h
@@ -30,6 +30,8 @@
 #include <pthread.h>
 #endif
 
+namespace ar
+{
 
 /**
  * Exception thrown for threading related errors, including errors with
@@ -183,5 +185,6 @@ private:
     size_t m_count;
 };
 
+} // namespace ar
 
 #endif

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -32,6 +32,8 @@
 #include "timer.h"
 #include "threads.h"
 
+namespace ar
+{
 
 //! Print progress report every N items
 const size_t REPORT_EVERY = 1e6;
@@ -163,3 +165,5 @@ void timer::do_print(size_t rate, double current_time, bool finalize) const
         std::cerr.flush();
     }
 }
+
+} // namespace ar

--- a/src/timer.h
+++ b/src/timer.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <deque>
 
+namespace ar
+{
 
 /**
  * Simply class for reporting current progress of a run.
@@ -71,5 +73,6 @@ private:
     time_count_deque m_counts;
 };
 
+} // namespace ar
 
 #endif

--- a/src/userconfig.cc
+++ b/src/userconfig.cc
@@ -35,6 +35,8 @@
 #include "alignment.h"
 #include "strutils.h"
 
+namespace ar
+{
 
 size_t get_seed()
 {
@@ -685,3 +687,5 @@ bool userconfig::setup_adapter_sequences()
 
     return true;
 }
+
+} // namespace ar

--- a/src/userconfig.h
+++ b/src/userconfig.h
@@ -34,7 +34,8 @@
 #include "alignment.h"
 #include "statistics.h"
 
-
+namespace ar
+{
 
 struct alignment_info;
 
@@ -198,5 +199,6 @@ private:
     unsigned quality_max;
 };
 
+} // namespace ar
 
 #endif

--- a/src/vecutils.h
+++ b/src/vecutils.h
@@ -26,6 +26,8 @@
 
 #include <vector>
 
+namespace ar
+{
 
 /**
  * Merge two vectors by adding each value in src to each value in 'dst'.
@@ -66,5 +68,6 @@ void merge_sub_vectors(std::vector<std::vector<T> >& dst, const std::vector<std:
     }
 }
 
+} // namespace ar
 
 #endif

--- a/tests/alignment_test.cc
+++ b/tests/alignment_test.cc
@@ -30,6 +30,8 @@
 #include "alignment.h"
 #include "fastq.h"
 
+namespace ar
+{
 
 alignment_info new_aln(int score = 0, int offset = 0, size_t length = 0,
                        size_t nmm = 0, size_t nn = 0, int adapter = 0)
@@ -1090,3 +1092,5 @@ TEST(compare_subsequences, brute_force_validation)
         }
     }
 }
+
+} // namespace ar

--- a/tests/argparse_test.cc
+++ b/tests/argparse_test.cc
@@ -29,6 +29,8 @@
 #include "argparse.h"
 #include "debug.h"
 
+namespace ar
+{
 
 typedef std::auto_ptr<argparse::consumer_base> consumer_autoptr;
 
@@ -380,3 +382,4 @@ TEST(floaty_knob, trailing_garbage)
 ///////////////////////////////////////////////////////////////////////////////
 // parser
 
+} // namespace ar

--- a/tests/fastq_test.cc
+++ b/tests/fastq_test.cc
@@ -29,6 +29,8 @@
 #include "fastq.h"
 #include "linereader.h"
 
+namespace ar
+{
 
 inline std::ostream& operator<<(std::ostream& stream, const fastq& record)
 {
@@ -752,3 +754,5 @@ TEST(fastq, validate_paired_reads__throws_if_name_differs)
    const fastq mate1 = fastq("WrongName/2", "ACGT", "!!#$");
    ASSERT_THROW(fastq::validate_paired_reads(mate1, mate2), fastq_error);
 }
+
+} // namespace ar

--- a/tests/strutils_test.cc
+++ b/tests/strutils_test.cc
@@ -28,6 +28,8 @@
 
 #include "strutils.h"
 
+namespace ar
+{
 
 ///////////////////////////////////////////////////////////////////////////////
 // Tests for 'indent_lines'
@@ -154,3 +156,4 @@ TEST(strutils_columnize, ljust)
     ASSERT_EQ("foo\n  bar\n  zood", columnize_text("foo bar\nzood", 0, 2));
 }
 
+} // namespace ar


### PR DESCRIPTION
Hello.

Thank you for contributing this software. I am interested in using it in my project but needed an easy way to include it. This PR enables creation of a static library using `make static` which other projects can easily link to. Furthermore, I moved the code from the default namespace to a new namespace called "ar" to remove possible conflicts with other libraries.

Regards,
Hannes