### PR TITLE
Accept suffixes .1 and .2 for mate pair names.

### DIFF
--- a/src/fastq.cc
+++ b/src/fastq.cc
@@ -68,10 +68,10 @@ inline mate_info get_mate_information(const fastq& read)
 
     if (pos >= 2) {
         const std::string substr = header.substr(0, pos);
-        if (substr.substr(pos - 2) == "/1") {
+        if (substr.substr(pos - 2) == "/1" || substr.substr(pos - 2) == ".1") {
             info.mate = mate_info::mate1;
             pos -= 2;
-        } else if (substr.substr(pos - 2) == "/2") {
+        } else if (substr.substr(pos - 2) == "/2" || substr.substr(pos - 2) == ".2") {
             info.mate = mate_info::mate2;
             pos -= 2;
         }


### PR DESCRIPTION
I just downloaded 600GB of data from SRA and the mate pairs use .1 and .2 suffixes instead of /1 and /2. Yech!

Without this change, AdapterRemoval complains:
"Pair contains reads with mismatching names: 'SRR1217908.1.1' and 'SRR1217908.1.2"