### PR TITLE
Work in progress: Windowed quality trimming

### DIFF
--- a/src/fastq.h
+++ b/src/fastq.h
@@ -25,6 +25,8 @@
 #ifndef FASTQ_H
 #define FASTQ_H
 
+#include <iostream>
+
 #include <string>
 
 #include "commontypes.h"
@@ -111,7 +113,7 @@ public:
      * @param low_quality Trim bases with a quality score at or below this value.
      * @return A pair containing hte number of bases trimmed from either end.
      */
-	ntrimmed trim_low_quality_bases(bool trim_ns = true, char low_quality = -1);
+	ntrimmed trim_low_quality_bases(bool trim_ns = true, char low_quality = -1, const size_t winlen=1);
 
     /**
      * Truncates the record in place.

--- a/src/userconfig.cc
+++ b/src/userconfig.cc
@@ -93,6 +93,7 @@ userconfig::userconfig(const std::string& name,
     , quality_input_fmt()
     , quality_output_fmt()
     , trim_by_quality(false)
+    , window_len(1)
     , low_quality_score(2)
     , trim_ambiguous_bases(false)
     , max_ambiguous_bases(1000)
@@ -285,11 +286,17 @@ userconfig::userconfig(const std::string& name,
             "[current: %default]");
     argparser["--trimqualities"] =
         new argparse::flag(&trim_by_quality,
-            "If set, trim bases at 5'/3' termini with quality scores <= to "
-            "--minquality value [current: %default]");
+            "If set, use a windowed qualitry trimming algorithm to trim bases "
+            "with quality scores <= to --minquality value "
+            "[current: %default]");
+    argparser["--qualwinlen"] =
+        new argparse::knob(&window_len, "INT",
+            "Window size; see --trimqualities for details "
+            "[current: %default]");
     argparser["--minquality"] =
         new argparse::knob(&low_quality_score, "PHRED",
-            "Inclusive minimum; see --trimqualities for details "
+            "Inclusive minimum; see --trimqualities for details. Set to 1 to "
+            "disable window-based QC and revert to 5'/3'-terminal trimming "
             "[current: %default]");
     argparser["--minlength"] =
         new argparse::knob(&min_genomic_length, "LENGTH",
@@ -700,7 +707,8 @@ fastq::ntrimmed userconfig::trim_sequence_by_quality_if_enabled(fastq& read) con
     if (trim_ambiguous_bases || trim_by_quality) {
         char quality_score = trim_by_quality ? low_quality_score : -1;
         trimmed = read.trim_low_quality_bases(trim_ambiguous_bases,
-                                              quality_score);
+                                              quality_score,
+                                              window_len);
     }
 
     return trimmed;

--- a/src/userconfig.h
+++ b/src/userconfig.h
@@ -133,6 +133,8 @@ public:
 
     //! If true, read termini are trimmed for low-quality bases.
     bool trim_by_quality;
+    //! Window size for windowed Qual trim
+    unsigned window_len;
     //! The highest quality score which is considered low-quality
     unsigned low_quality_score;
 

--- a/tests/fastq_test.cc
+++ b/tests/fastq_test.cc
@@ -295,7 +295,7 @@ TEST(fastq, trim_low_quality_bases__trim_window)
     fastq record("Rec", "NNAAAAAAAAATNNNNNNNA", "##EEEEEEEEEE#######E");
     const fastq expected_record = fastq("Rec", "AAAAAAAAAT", "EEEEEEEEEE");
     const fastq::ntrimmed expected_ntrim(2, 8);
-    ASSERT_EQ(expected_ntrim, record.trim_low_quality_bases(true, 10));
+    ASSERT_EQ(expected_ntrim, record.trim_low_quality_bases(true, 10, 5));
     ASSERT_EQ(expected_record, record);
 }
 

--- a/tests/fastq_test.cc
+++ b/tests/fastq_test.cc
@@ -246,9 +246,9 @@ TEST(fastq, trim_low_quality_bases__trim_nothing)
 
 TEST(fastq, trim_low_quality_bases__trim_ns)
 {
+    fastq record("Rec", "NNANT", "23456");
     const fastq expected_record("Rec", "ANT", "456");
     const fastq::ntrimmed expected_ntrim(2, 0);
-    fastq record("Rec", "NNANT", "23456");
 
     ASSERT_EQ(expected_ntrim, record.trim_low_quality_bases(true, -1));
     ASSERT_EQ(expected_record, record);
@@ -257,29 +257,29 @@ TEST(fastq, trim_low_quality_bases__trim_ns)
 
 TEST(fastq, trim_low_quality_bases__trim_low_quality_bases)
 {
-    const fastq expected_record("Rec", "TN", "%$");
+    const fastq expected_record("Rec", "TN", "JJ");
     const fastq::ntrimmed expected_ntrim(0, 3);
-    fastq record("Rec", "TNANT", "%$#!\"");
+    fastq record("Rec", "TNANT", "JJ###");
 
-    ASSERT_EQ(expected_ntrim, record.trim_low_quality_bases(false, 2));
+    ASSERT_EQ(expected_ntrim, record.trim_low_quality_bases(false, 10));
     ASSERT_EQ(expected_record, record);
 }
 
 
 TEST(fastq, trim_low_quality_bases__trim_mixed)
 {
-    const fastq expected_record("Rec", "TAG", "$12");
-    const fastq::ntrimmed expected_ntrim(3, 2);
-    fastq record("Rec", "NTNTAGNT", "1!#$12#\"");
+    const fastq expected_record("Rec", "AAANAAA", "JJJ#JJJ");
+    const fastq::ntrimmed expected_ntrim(1, 2);
+    fastq record("Rec", "NAAANAAANT", "#JJJ#JJJ##");
 
-    ASSERT_EQ(expected_ntrim, record.trim_low_quality_bases(true, 2));
+    ASSERT_EQ(expected_ntrim, record.trim_low_quality_bases(true, 10));
     ASSERT_EQ(expected_record, record);
 }
 
 
 TEST(fastq, trim_low_quality_bases__trim_mixed__no_low_quality_bases)
 {
-    const fastq expected_record("Rec", "ACTTAG", "12I$12");
+    const fastq expected_record("Rec", "ACTTAG", "JJJJJJ");
     const fastq::ntrimmed expected_ntrim(0, 0);
     fastq record = expected_record;
 
@@ -288,12 +288,23 @@ TEST(fastq, trim_low_quality_bases__trim_mixed__no_low_quality_bases)
 }
 
 
+TEST(fastq, trim_low_quality_bases__trim_window)
+{
+    // Should trim starting at the window of low quality bases in the middle
+    // even with high qual bases at the end.
+    fastq record("Rec", "NNAAAAAAAAATNNNNNNNA", "##EEEEEEEEEE#######E");
+    const fastq expected_record = fastq("Rec", "AAAAAAAAAT", "EEEEEEEEEE");
+    const fastq::ntrimmed expected_ntrim(2, 8);
+    ASSERT_EQ(expected_ntrim, record.trim_low_quality_bases(true, 10));
+    ASSERT_EQ(expected_record, record);
+}
+
 TEST(fastq, trim_low_quality_bases__trim_everything)
 {
     fastq record("Rec", "TAG", "!!!");
     const fastq expected_record = fastq("Rec", "", "");
     const fastq::ntrimmed expected_ntrim(0, 3);
-    ASSERT_EQ(expected_ntrim, record.trim_low_quality_bases(true, 2));
+    ASSERT_EQ(expected_ntrim, record.trim_low_quality_bases(true, 10));
     ASSERT_EQ(expected_record, record);
 }
 


### PR DESCRIPTION
Hi Mikkel,

A few months ago, I tried to implement [sickle](https://github.com/najoshi/sickle)-style quality trimming within `AdaptorRemoval`. This method of trimming allows for more effective quality score trimming where the mean quality is low, but individual bases may have high quality, a common situation in modern Illumina sequencing runs in our experience.

At the moment, this pull request mostly works, however there are a couple of bugs that have stopped me using this. I'm quite busy at the moment, so I thought I'd show you the work as it is.

Is this something that you would want implemented within AdaptorRemoval? If so, I will try to finish this off eventually (though not for a month or so). Feel free to take this work and finish it yourself if you would like.

Cheers,
Kevin
