### PR TITLE
add option for multiple input files

### DIFF
--- a/src/argparse.cc
+++ b/src/argparse.cc
@@ -417,6 +417,49 @@ std::string any::to_str() const
     }
 }
 
+///////////////////////////////////////////////////////////////////////////////
+
+anymulti::anymulti(string_vec* value, const std::string& metavar, const std::string& help)
+    : consumer_base(metavar, help)
+    , m_ptr(value)
+    , m_sink()
+{
+}
+
+
+size_t anymulti::consume(string_vec_citer start, const string_vec_citer& end)
+{
+    if (start != end) {
+        m_value_set = true;
+        if (m_ptr) {
+            m_ptr->push_back(*start);
+        } else {
+            m_sink.push_back(*start);
+        }
+
+        return 1;
+    }
+
+    return static_cast<size_t>(-1);
+}
+
+
+std::string anymulti::to_str() const
+{
+    const string_vec& result_vec = m_ptr ? *m_ptr : m_sink;
+    if (result_vec.empty()) {
+        return "<not set>";
+    } else {
+      std::string result;
+      string_vec_citer it = result_vec.begin();
+      result += *(it++);//We already checked that result_vec is not empty
+      while (it != result_vec.end()) {
+        result += ",";
+        result += *(it++);
+      }
+      return result;
+    }
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -306,6 +306,34 @@ private:
     std::string m_sink;
 };
 
+/**
+ * Consumer for multiple unsigned string values (filenames, etc.).
+ */
+class anymulti : public consumer_base
+{
+public:
+    /**
+     * See consumer_base::consumer_base
+     */
+    anymulti(string_vec* sink = NULL, const std::string& metavar = "", const std::string& help = "");
+
+    /** See consumer_base::consume */
+    virtual size_t consume(string_vec_citer start, const string_vec_citer& end);
+
+    /** See consumer_base::to_str */
+    virtual std::string to_str() const;
+
+private:
+    //! Not implemented
+    anymulti(const anymulti&);
+    //! Not implemented
+    anymulti& operator=(const anymulti&);
+
+    //! Optional pointer to storage for string value; if NULL, m_value is used.
+    string_vec* m_ptr;
+    //! Value sink used if a pointer to a sink is not provided.
+    string_vec m_sink;
+};
 
 /**
  * Consumer for unsigned integer values.

--- a/src/main_adapter_id.cc
+++ b/src/main_adapter_id.cc
@@ -474,13 +474,13 @@ int identify_adapter_sequences(const userconfig& config)
         if (config.interleaved_input) {
             sch.add_step(ai_read_fastq, "read_interleaved_fastq",
                          new read_interleaved_fastq(config.quality_input_fmt.get(),
-                                                    config.input_file_1,
+                                                    config.input_file_1[0],
                                                     ai_identify_adapters));
         } else {
             sch.add_step(ai_read_fastq, "read_paired_fastq",
                          new read_paired_fastq(config.quality_input_fmt.get(),
-                                               config.input_file_1,
-                                               config.input_file_2,
+                                               config.input_file_1[0],
+                                               config.input_file_2[0],
                                                ai_identify_adapters));
         }
     } catch (const std::ios_base::failure& error) {

--- a/src/main_demultiplex.cc
+++ b/src/main_demultiplex.cc
@@ -275,7 +275,7 @@ int demultiplex_sequences_se(const userconfig& config)
         // Step 1: Read input file
         sch.add_step(ai_read_fastq, "read_fastq",
                      new read_single_fastq(config.quality_input_fmt.get(),
-                                           config.input_file_1,
+                                           config.input_file_1[0],
                                            ai_demultiplex));
 
         // Step 2: Parse and demultiplex reads based on single or double indices
@@ -330,13 +330,13 @@ int demultiplex_sequences_pe(const userconfig& config)
         if (config.interleaved_input) {
             sch.add_step(ai_read_fastq, "read_interleaved_fastq",
                          new read_interleaved_fastq(config.quality_input_fmt.get(),
-                                                    config.input_file_1,
+                                                    config.input_file_1[0],
                                                     ai_demultiplex));
         } else {
             sch.add_step(ai_read_fastq, "read_paired_fastq",
                          new read_paired_fastq(config.quality_input_fmt.get(),
-                                               config.input_file_1,
-                                               config.input_file_2,
+                                               config.input_file_1[0],
+                                               config.input_file_2[0],
                                                ai_demultiplex));
         }
 

--- a/src/userconfig.cc
+++ b/src/userconfig.cc
@@ -122,12 +122,12 @@ userconfig::userconfig(const std::string& name,
     , demultiplex_sequences(false)
 {
     argparser["--file1"] =
-        new argparse::any(&input_file_1, "FILE",
-            "Input file containing mate 1 reads or single-ended reads "
-            "[REQUIRED].");
+        new argparse::anymulti(&input_file_1, "FILE",
+              "Input file(s) containing mate 1 reads or single-ended reads "
+              "[REQUIRED].");
     argparser["--file2"] =
-        new argparse::any(&input_file_2, "FILE",
-            "Input file containing mate 2 reads [OPTIONAL].");
+        new argparse::anymulti(&input_file_2, "FILE",
+            "Input file(s) containing mate 2 reads [OPTIONAL].");
 
     argparser.add_header("FASTQ OPTIONS:");
     argparser["--qualitybase"] =
@@ -461,6 +461,10 @@ argparse::parse_result userconfig::parse_args(int argc, char *argv[])
         std::cerr << "Error: --file2 specified, but --file1 is not specified." << std::endl;
 
         return argparse::pr_error;
+    } else if (file_2_set && input_file_1.size() != input_file_2.size()) {
+      std::cerr << "Error: Count of input files must match, but (--file1 != --file2) (" << input_file_1.size() << " != " << input_file_2.size() << ")." << std::endl;
+
+      return argparse::pr_error;
     } else if (file_2_set) {
         paired_ended_mode = true;
         min_adapter_overlap = 0;

--- a/src/userconfig.h
+++ b/src/userconfig.h
@@ -95,10 +95,10 @@ public:
 
     //! Prefix used for output files for which no filename was explicitly set
     std::string basename;
-    //! Path to input file containing mate 1 reads (required)
-    std::string input_file_1;
-    //! Path to input file containing mate 2 reads (for PE reads)
-    std::string input_file_2;
+    //! Path(s) to input file containing mate 1 reads (required)
+    string_vec input_file_1;
+    //! Path(s) to input file containing mate 2 reads (for PE reads)
+    string_vec input_file_2;
 
     //! Set to true if both --input1 and --input2 are set, or if either of
     //! --interleaved or --interleaved-input are set.


### PR DESCRIPTION
only supporting adapter trimming so far

Supporting #14 

This is my first c++ for quite a while so read with care. Hopefully this will save some work. Let me know if this seems good to you (or otherwise). If you want me to work on some areas let me know.

Not sure what is the best thing to return in read_single/paired_fastq::process when the file can't be opened. Previously chunk was always NULL so chunk_vec() was returned. Now chunk might not be, so I attempted to return chunk instead. Not sure if that makes sense or is done in the correct way or not.