### PR TITLE
skip no-commit-to-branch pre-commit hook during CI

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    env:
+      SKIP: no-commit-to-branch
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3


### PR DESCRIPTION
This would cause failures post-merge with master branch