### PR TITLE
switch to fastjsonschema

### DIFF
--- a/tests/regression/meson.build
+++ b/tests/regression/meson.build
@@ -107,7 +107,6 @@ foreach test : regression_tests
         + [
             meson.current_build_dir(),
             meson.current_source_dir() / test,
-            '--threads', '1',
             '--use-colors', 'always',
             '--json-schema', meson.project_source_root() / 'schema.json',
             '--executable', exe.full_path(),


### PR DESCRIPTION
This significantly reduces the runtime of regression tests. Built-in support for parallel
execution of tests was dropped, for simplicity