### PR TITLE
tweaks to html report

### DIFF
--- a/src/reports_html.cpp
+++ b/src/reports_html.cpp
@@ -827,7 +827,7 @@ write_html_analyses_section(const userconfig& config,
     ss << "Insert sizes inferred for "
        << format_percentage(insert_sizes.sum(),
                             stats.input_1->number_of_input_reads())
-       << "% of reads";
+       << " of reads";
 
     html_plot_title()
       .set_href("analyses-insert-sizes")

--- a/src/reports_template.html
+++ b/src/reports_template.html
@@ -200,7 +200,7 @@
     }
 
     div#layout {
-      max-width: 920px;
+      width: 920px;
       margin-left: auto;
       margin-right: auto;
       font-size: smaller;
@@ -745,19 +745,18 @@
 
     <div class="section note epilogue">
       <p>
+        For comments, suggestions, or feedback, please use
+        <a href="https://github.com/MikkelSchubert/adapterremoval/issues/new">GitHub Issues</a>.
+
         If you use AdapterRemoval, please cite
         <a href="https://doi.org/10.1186/s13104-016-1900-2">Schubert et. al. 2016</a>:
       </p>
 
-      <p style="font-family: monospace; padding-left: 2em; padding-right: 2em; max-width: 50%;">
+      <p style="font-family: monospace; padding-left: 2em; padding-right: 2em;">
         Schubert, Lindgreen, and Orlando (2016). AdapterRemoval v2: rapid adapter trimming, identification, and
         read merging. BMC Research Notes, 12;9(1):88.
       </p>
 
-      <p>
-        For comments, suggestions, or feedback, please use
-        <a href="https://github.com/MikkelSchubert/adapterremoval/issues/new">GitHub Issues</a>.
-      </p>
       <p>
         This report was generated using <a href="https://purecss.io/">Pure</a> (<a
           href="https://github.com/pure-css/pure/blob/v2.1.0/LICENSE">license</a>) and <a

--- a/src/reports_template.html
+++ b/src/reports_template.html
@@ -494,9 +494,9 @@
             <th>Stage</th>
             <th>Step</th>
             <th></th>
-            <th>Bases</th>
-            <th>(%)</th>
             <th>Reads</th>
+            <th>(%)</th>
+            <th>Bases</th>
             <th>(%)</th>
             <th>Mean Bases</th>
           </tr>
@@ -507,10 +507,10 @@
             <td>{{STAGE}}</td>
             <td>{{LABEL_1}}</td>
             <td>{{LABEL_2}}</td>
-            <td>{{BASES}}</td>
-            <td>{{PCT_BASES}}</td>
             <td>{{READS}}</td>
             <td>{{PCT_READS}}</td>
+            <td>{{BASES}}</td>
+            <td>{{PCT_BASES}}</td>
             <td>{{AVG_BASES}}</td>
           </tr>
           <!-- TEMPLATE: SUMMARY_TRIMMING_TAIL -->


### PR DESCRIPTION
Change the order of the summary table for consistency with input / output tables, fix a double percentage sign, remove cap on width of citation text, and fix text potentially being resized to a lower width than the static report paragraph width.