### PR TITLE
rework unit tests to check exception messages

### DIFF
--- a/src/fastq_enc.cpp
+++ b/src/fastq_enc.cpp
@@ -81,6 +81,17 @@ const auto g_solexa_to_phred33 = calc_solexa_to_phred33();
 
 ///////////////////////////////////////////////////////////////////////////////
 
+/**
+ * Uppercase letters in the range a-z, but mangles other characters. Resulting
+ * values outside of A-Z should be compared against/reported, since they may not
+ * reflect the original value.
+ */
+constexpr char
+mangle_to_upper(const char c)
+{
+  return c & 0xDF;
+}
+
 /** Returns the quality score in a form that is human readable */
 std::string
 escape_raw_score(char raw)
@@ -225,7 +236,7 @@ throw_invalid_base(char c)
 {
   std::ostringstream stream;
 
-  switch (c) {
+  switch (mangle_to_upper(c)) {
     case 'B': // C / G / T
     case 'D': // A / G / T
     case 'H': // A / C / T
@@ -261,7 +272,7 @@ process_nucleotides_strict(std::string& nucleotides)
 {
   for (char& nuc : nucleotides) {
     // Fast ASCII letter uppercase
-    const auto upper_case = nuc & 0xDF;
+    const auto upper_case = mangle_to_upper(nuc);
     switch (upper_case) {
       case 'A':
       case 'C':
@@ -284,7 +295,7 @@ process_nucleotides_lenient(std::string& nucleotides,
 {
   for (char& nuc : nucleotides) {
     // Fast ASCII letter uppercase
-    const auto upper_case = nuc & 0xDF;
+    const auto upper_case = mangle_to_upper(nuc);
     switch (upper_case) {
       case 'A':
       case 'C':

--- a/tests/unit/argparse_test.cpp
+++ b/tests/unit/argparse_test.cpp
@@ -275,9 +275,9 @@ TEST_CASE("with uint minimum", "[argparse::u32_sink]")
   SECTION("fail")
   {
     string_vec values{ "99" };
-    REQUIRE_THROWS_MATCHES(sink.consume(values.begin(), values.end()),
+    REQUIRE_THROWS_MESSAGE(sink.consume(values.begin(), values.end()),
                            std::invalid_argument,
-                           Catch::Message("value must be at least 100"));
+                           "value must be at least 100");
     REQUIRE(value != 0);
   }
 }
@@ -319,9 +319,9 @@ TEST_CASE("with uint maximum", "[argparse::u32_sink]")
   SECTION("fail")
   {
     string_vec values{ "101" };
-    REQUIRE_THROWS_MATCHES(sink.consume(values.begin(), values.end()),
+    REQUIRE_THROWS_MESSAGE(sink.consume(values.begin(), values.end()),
                            std::invalid_argument,
-                           Catch::Message("value must be at most 100"));
+                           "value must be at most 100");
     REQUIRE(value != 101);
   }
 }

--- a/tests/unit/linereader_test.cpp
+++ b/tests/unit/linereader_test.cpp
@@ -26,6 +26,7 @@
 #include <libdeflate.h>   // for libdeflate_alloc_compressor, libdeflate_free...
 #include <string>         // for string, basic_string, operator==
 #include <vector>         // for operator==, vector
+#include "strutils.hpp"   // for log_escape
 
 namespace adapterremoval {
 
@@ -91,8 +92,8 @@ TEST_CASE("line_reader throws on null")
 TEST_CASE("line_reader throws on missing file")
 {
   // This file hopefully does not exist ...
-  REQUIRE_THROWS_AS(line_reader("eb8d324f-bae2-4484-894a-883b6abacc6b"),
-                    io_error);
+  REQUIRE_THROWS_WITH(line_reader("eb8d324f-bae2-4484-894a-883b6abacc6b"),
+                      Catch::Contains("failed to open file:"));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -283,3 +284,14 @@ TEST_CASE("line_reader handles gzipped file with trailing junk")
 }
 
 } // namespace adapterremoval
+
+namespace Catch {
+using namespace adapterremoval;
+
+template<>
+std::string
+StringMaker<io_error, void>::convert(io_error const& value)
+{
+  return log_escape(value.what());
+}
+} // namespace Catch

--- a/tests/unit/sequence_sets_test.cpp
+++ b/tests/unit/sequence_sets_test.cpp
@@ -20,6 +20,8 @@
 #include "errors.hpp"        // for parsing_error
 #include "sequence_sets.hpp" // for read_group
 #include "testing.hpp"       // for catch.hpp, StringMaker
+#include <stdexcept>         // for invalid_argument
+#include "strutils.hpp"      // for log_escape
 
 using Contains = Catch::Matchers::StdString::ContainsMatcher;
 
@@ -111,24 +113,32 @@ TEST_CASE("unsetting read group fields")
 
 TEST_CASE("invalid read groups")
 {
-  REQUIRE_THROWS_WITH(read_group{ "ID:" },
-                      "tags must be at least 4 characters long");
+  REQUIRE_THROWS_MESSAGE(read_group{ "ID:" },
+                         std::invalid_argument,
+                         "tags must be at least 4 characters long");
 
-  REQUIRE_THROWS_WITH(read_group{ "1D:1" },
-                      "first character in tag name must be a letter");
-  REQUIRE_THROWS_WITH(read_group{ "!D:1" },
-                      "first character in tag name must be a letter");
+  REQUIRE_THROWS_MESSAGE(read_group{ "1D:1" },
+                         std::invalid_argument,
+                         "first character in tag name must be a letter");
+  REQUIRE_THROWS_MESSAGE(read_group{ "!D:1" },
+                         std::invalid_argument,
+                         "first character in tag name must be a letter");
 
-  REQUIRE_THROWS_WITH(
-    read_group{ "D!:1" },
-    "second character in tag name must be a letter or number");
+  REQUIRE_THROWS_MESSAGE(read_group{ "D!:1" },
+                         std::invalid_argument,
+                         "second character in tag name must be a letter or "
+                         "number");
 
-  REQUIRE_THROWS_WITH(read_group{ "ID:1\tID:2" }, "multiple ID tags found");
+  REQUIRE_THROWS_MESSAGE(read_group{ "ID:1\tID:2" },
+                         std::invalid_argument,
+                         "multiple ID tags found");
 
-  REQUIRE_THROWS_WITH(read_group{ "ID?1" },
-                      "third character in tag must be a colon");
-  REQUIRE_THROWS_WITH(read_group{ "ID:1\nSM:foo" },
-                      "only characters in the range ' ' to '~' are allowed");
+  REQUIRE_THROWS_MESSAGE(read_group{ "ID?1" },
+                         std::invalid_argument,
+                         "third character in tag must be a colon");
+  REQUIRE_THROWS_MESSAGE(read_group{ "ID:1\nSM:foo" },
+                         std::invalid_argument,
+                         "only characters in the range ' ' to '~' are allowed");
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -138,14 +148,24 @@ TEST_CASE("Overlapping SE barcodes fail", "[sample_set::initializer_list]")
 {
   sample sample1{ "sample1", dna_sequence{ "ACGT" }, dna_sequence{} };
   sample sample2{ "sample2", dna_sequence{ "ACGT" }, dna_sequence{} };
-  REQUIRE_THROWS_AS(sample_set({ sample1, sample2 }), parsing_error);
+  REQUIRE_THROWS_MESSAGE(
+    sample_set({ sample1, sample2 }),
+    parsing_error,
+    "Duplicate barcode pairs found in \'initializer_list\' with barcodes "
+    "\'ACGT\' and \'\'. please verify correctness of the barcode table and "
+    "remove any duplicate entries!");
 }
 
 TEST_CASE("Overlapping PE barcodes fail", "[sample_set::initializer_list]")
 {
   sample sample1{ "sample1", dna_sequence{ "ACGT" }, dna_sequence{ "CGTG" } };
   sample sample2{ "sample2", dna_sequence{ "ACGT" }, dna_sequence{ "CGTG" } };
-  REQUIRE_THROWS_AS(sample_set({ sample1, sample2 }), parsing_error);
+  REQUIRE_THROWS_MESSAGE(
+    sample_set({ sample1, sample2 }),
+    parsing_error,
+    "Duplicate barcode pairs found in \'initializer_list\' with barcodes "
+    "\'ACGT\' and \'CGTG\'. please verify correctness of the barcode table and "
+    "remove any duplicate entries!");
 }
 
 TEST_CASE("Variable length SE barcodes fail #1",
@@ -153,7 +173,12 @@ TEST_CASE("Variable length SE barcodes fail #1",
 {
   sample sample1{ "sample1", dna_sequence{ "ACGTA" }, dna_sequence{} };
   sample sample2{ "sample2", dna_sequence{ "TGCT" }, dna_sequence{} };
-  REQUIRE_THROWS_AS(sample_set({ sample1, sample2 }), parsing_error);
+  REQUIRE_THROWS_MESSAGE(
+    sample_set({ sample1, sample2 }),
+    parsing_error,
+    "Inconsistent mate 1 barcode lengths found: Last barcode was 5 base-pairs "
+    "long, but barcode \'TGCT\' is 4 base-pairs long. Variable length barcodes "
+    "are not supported");
 }
 
 TEST_CASE("Variable length SE barcodes fail #2",
@@ -161,7 +186,12 @@ TEST_CASE("Variable length SE barcodes fail #2",
 {
   sample sample1{ "sample1", dna_sequence{ "ACGT" }, dna_sequence{} };
   sample sample2{ "sample2", dna_sequence{ "TGCTA" }, dna_sequence{} };
-  REQUIRE_THROWS_AS(sample_set({ sample1, sample2 }), parsing_error);
+  REQUIRE_THROWS_MESSAGE(
+    sample_set({ sample1, sample2 }),
+    parsing_error,
+    "Inconsistent mate 1 barcode lengths found: Last barcode was 4 base-pairs "
+    "long, but barcode \'TGCTA\' is 5 base-pairs long. Variable length "
+    "barcodes are not supported");
 }
 
 TEST_CASE("Variable length PE barcodes fail #1",
@@ -169,7 +199,12 @@ TEST_CASE("Variable length PE barcodes fail #1",
 {
   sample sample1{ "sample1", dna_sequence{ "ACGTT" }, dna_sequence{ "CGTG" } };
   sample sample2{ "sample2", dna_sequence{ "CGTG" }, dna_sequence{ "ACGT" } };
-  REQUIRE_THROWS_AS(sample_set({ sample1, sample2 }), parsing_error);
+  REQUIRE_THROWS_MESSAGE(
+    sample_set({ sample1, sample2 }),
+    parsing_error,
+    "Inconsistent mate 1 barcode lengths found: Last barcode was 5 base-pairs "
+    "long, but barcode \'CGTG\' is 4 base-pairs long. Variable length barcodes "
+    "are not supported");
 }
 
 TEST_CASE("Variable length PE barcodes fail #2",
@@ -177,7 +212,12 @@ TEST_CASE("Variable length PE barcodes fail #2",
 {
   sample sample1{ "sample1", dna_sequence{ "ACGT" }, dna_sequence{ "CGTGT" } };
   sample sample2{ "sample2", dna_sequence{ "CGTG" }, dna_sequence{ "ACGT" } };
-  REQUIRE_THROWS_AS(sample_set({ sample1, sample2 }), parsing_error);
+  REQUIRE_THROWS_MESSAGE(
+    sample_set({ sample1, sample2 }),
+    parsing_error,
+    "Inconsistent mate 2 barcode lengths found: Last barcode was 5 base-pairs "
+    "long, but barcode \'ACGT\' is 4 base-pairs long. Variable length barcodes "
+    "are not supported");
 }
 
 TEST_CASE("Variable length PE barcodes fail #3",
@@ -185,7 +225,12 @@ TEST_CASE("Variable length PE barcodes fail #3",
 {
   sample sample1{ "sample1", dna_sequence{ "ACGT" }, dna_sequence{ "CGTG" } };
   sample sample2{ "sample2", dna_sequence{ "CGTGA" }, dna_sequence{ "ACGT" } };
-  REQUIRE_THROWS_AS(sample_set({ sample1, sample2 }), parsing_error);
+  REQUIRE_THROWS_MESSAGE(
+    sample_set({ sample1, sample2 }),
+    parsing_error,
+    "Inconsistent mate 1 barcode lengths found: Last barcode was 4 base-pairs "
+    "long, but barcode \'CGTGA\' is 5 base-pairs long. Variable length "
+    "barcodes are not supported");
 }
 
 TEST_CASE("Variable length PE barcodes fail #4",
@@ -193,7 +238,25 @@ TEST_CASE("Variable length PE barcodes fail #4",
 {
   sample sample1{ "sample1", dna_sequence{ "ACGT" }, dna_sequence{ "CGTG" } };
   sample sample2{ "sample2", dna_sequence{ "CGTGA" }, dna_sequence{ "ACGTA" } };
-  REQUIRE_THROWS_AS(sample_set({ sample1, sample2 }), parsing_error);
+  REQUIRE_THROWS_MESSAGE(
+    sample_set({ sample1, sample2 }),
+    parsing_error,
+    "Inconsistent mate 1 barcode lengths found: Last barcode was 4 base-pairs "
+    "long, but barcode \'CGTGA\' is 5 base-pairs long. Variable length "
+    "barcodes are not supported");
 }
 
 } // namespace adapterremoval
+
+namespace Catch {
+
+using namespace adapterremoval;
+
+template<>
+std::string
+StringMaker<parsing_error, void>::convert(parsing_error const& value)
+{
+  return log_escape(value.what());
+}
+
+} // namespace Catch

--- a/tests/unit/testing.hpp
+++ b/tests/unit/testing.hpp
@@ -34,4 +34,12 @@ struct StringMaker<
   static std::string convert(T const& value);
 };
 
+/** Helper macro for typed catching of thrown messages */
+#define REQUIRE_THROWS_MESSAGE(expr, exceptionType, message)                   \
+  REQUIRE_THROWS_MATCHES(expr, exceptionType, Catch::Message(message))
+
+/** Helper macro for typed catching of thrown messages */
+#define CHECK_THROWS_MESSAGE(expr, exceptionType, message)                     \
+  CHECK_THROWS_MATCHES(expr, exceptionType, Catch::Message(message))
+
 } // namespace Catch


### PR DESCRIPTION
This includes fixing a pointless test and a improper error messages on lowercase degenerate FASTQ bases