### PR TITLE
tweak ccache action max size

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             cxx: g++
             coverage: "true"
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             cxx: clang++
             coverage: "false"
           - os: macos-latest
@@ -27,6 +27,7 @@ jobs:
             coverage: "false"
       # Do not auto-cancel other runners if one fails
       fail-fast: false
+
     env:
       CXX: ${{ matrix.cxx }}
       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
@@ -51,9 +52,11 @@ jobs:
         with:
           key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.cxx }}
           create-symlink: true
+          # Set cache size to about 4 full builds
+          max-size: "100M"
 
       - name: dependencies (libraries)
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt-get install zlib1g-dev libisal-dev libdeflate-dev gcovr
 
       - name: dependencies (libraries)
@@ -65,6 +68,12 @@ jobs:
 
       - name: setup
         run: make setup DEBUG=true SANITIZE=true COVERAGE=${{ matrix.coverage }}
+
+      - name: compile (executable)
+        run: make executable DEBUG=true SANITIZE=true COVERAGE=${{ matrix.coverage }}
+
+      - name: compile (unit tests)
+        run: make test_executable DEBUG=true SANITIZE=true COVERAGE=${{ matrix.coverage }}
 
       - name: install
         run: make install DESTDIR=${PWD}/install

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ static: ${NINJAFILE}
 static-container: ${NINJAFILE}
 	meson compile -C "${BUILDDIR}" static-container
 
+test_executable: ${NINJAFILE}
+	meson compile -C "${BUILDDIR}" unit_tests
+
 test: ${NINJAFILE}
 	meson test -C "${BUILDDIR}" --print-errorlogs --suite unit
 


### PR DESCRIPTION
There is generally a high amount of churn in ccache files, due to the (currently) high level of interdependence between files, and cached files are therefore not expected have be relevant for a long time. The maximum size of the cache is therefore reduced to 100 MB, compared to the default maximum of 500 MB, in order to reduce the amount of time spent on (re)storing the cache.