### PR TITLE
use common constants for /dev/ paths and similiar

### DIFF
--- a/src/commontypes.hpp
+++ b/src/commontypes.hpp
@@ -3,8 +3,8 @@
 // SPDX-FileCopyrightText: 2014 Mikkel Schubert <mikkelsch@gmail.com>
 #pragma once
 
-#include <string_view> // for string_view
 #include <string>      // for string
+#include <string_view> // for string_view
 #include <vector>      // for vector
 
 namespace adapterremoval {

--- a/src/commontypes.hpp
+++ b/src/commontypes.hpp
@@ -3,8 +3,9 @@
 // SPDX-FileCopyrightText: 2014 Mikkel Schubert <mikkelsch@gmail.com>
 #pragma once
 
-#include <string>
-#include <vector>
+#include <string_view> // for string_view
+#include <string>      // for string
+#include <vector>      // for vector
 
 namespace adapterremoval {
 
@@ -74,5 +75,16 @@ enum class trimming_strategy
   //! The original quality trimming algorithms
   per_base,
 };
+
+//! Path used to indicate that a file is not needed
+const std::string_view DEV_NULL = "/dev/null";
+//! Path used to indicate that data should be read from STDIN
+const std::string_view DEV_STDIN = "/dev/stdout";
+//! Path used to indicate that data should be written to STDOUT
+const std::string_view DEV_STDOUT = "/dev/stdout";
+//! Path used to indicate that data should be written to STDOUT
+const std::string_view DEV_STDERR = "/dev/stderr";
+//! Filename indicating that data should be read from stdin/written to stdout
+const std::string_view DEV_PIPE = "-";
 
 } // namespace adapterremoval

--- a/src/managed_io.cpp
+++ b/src/managed_io.cpp
@@ -1,19 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2015 Mikkel Schubert <mikkelsch@gmail.com>
-#include "managed_io.hpp" // declarations
-#include "debug.hpp"      // for AR_REQUIRE
-#include "errors.hpp"     // for io_error
-#include "logging.hpp"    // for log::warn
-#include "strutils.hpp"   // for log_escape
-#include <algorithm>      // for any_of
-#include <cerrno>         // for EMFILE, errno
-#include <cstddef>        // for size_t
-#include <cstdio>         // for fopen, fread, fwrite, ...
-#include <exception>      // for std::exception
-#include <fcntl.h>        // for posix_fadvise
-#include <mutex>          // for mutex, lock_guard
-#include <string>         // for string
-#include <sys/stat.h>     // for fstat
+#include "managed_io.hpp"  // declarations
+#include "commontypes.hpp" // for DEV_STDOUT, DEV_STDERR, ...
+#include "debug.hpp"       // for AR_REQUIRE
+#include "errors.hpp"      // for io_error
+#include "logging.hpp"     // for log::warn
+#include "strutils.hpp"    // for log_escape
+#include <algorithm>       // for any_of
+#include <cerrno>          // for EMFILE, errno
+#include <cstddef>         // for size_t
+#include <cstdio>          // for fopen, fread, fwrite, ...
+#include <exception>       // for std::exception
+#include <fcntl.h>         // for posix_fadvise
+#include <mutex>           // for mutex, lock_guard
+#include <string>          // for string
+#include <sys/stat.h>      // for fstat
 
 namespace adapterremoval {
 
@@ -24,9 +25,9 @@ public:
   {
     if (reader->m_file) {
       return;
-    } else if (reader->filename() == "/dev/stdin") {
+    } else if (reader->filename() == DEV_STDIN) {
       reader->m_file = stdin;
-    } else if (reader->filename() != "-") {
+    } else if (reader->filename() != DEV_PIPE) {
       reader->m_file = io_manager::fopen(reader->filename(), "rb");
 
 #if (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 600) ||                        \
@@ -44,12 +45,12 @@ public:
   {
     if (writer->m_file) {
       return;
-    } else if (writer->filename() == "/dev/stdout") {
+    } else if (writer->filename() == DEV_STDOUT) {
       writer->m_file = stdout;
-    } else if (writer->filename() == "/dev/stderr") {
+    } else if (writer->filename() == DEV_STDERR) {
       // Not sure why anyone would do this, but ¯\_(ツ)_/¯
       writer->m_file = stderr;
-    } else if (writer->filename() != "-") {
+    } else if (writer->filename() != DEV_PIPE) {
       writer->m_file =
         io_manager::fopen(writer->filename(), writer->m_created ? "ab" : "wb");
     } else {

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2024 Mikkel Schubert <mikkelsch@gmail.com>
 #pragma once
 
-#include "commontypes.hpp" // for string_vec, read_type, merge_strategy
+#include "commontypes.hpp" // for string_vec, read_type, merge_strategy, ...
 #include <array>           // for array
 #include <cstddef>         // for size_t
 #include <memory>          // for unique_ptr
@@ -25,9 +25,6 @@ using chunk_ptr = std::unique_ptr<analytical_chunk>;
 using chunk_ptr_vec = std::vector<chunk_ptr>;
 using chunk_pair = std::pair<size_t, chunk_ptr>;
 using chunk_vec = std::vector<chunk_pair>;
-
-//! Path used to indicate that a file is not needed
-const std::string DEV_NULL = "/dev/null";
 
 struct output_file
 {
@@ -124,11 +121,11 @@ public:
   std::string settings_html{};
 
   //! Filename for unidentified mate 1 reads (demultiplexing)
-  output_file unidentified_1 = output_file{ DEV_NULL };
+  output_file unidentified_1{ std::string{ DEV_NULL } };
   //! Pipeline step responsible for compresssing/writing unidentified 1 reads
   size_t unidentified_1_step = disabled;
   //! Filename for unidentified mate 1 reads (demultiplexing)
-  output_file unidentified_2 = output_file{ DEV_NULL };
+  output_file unidentified_2{ std::string{ DEV_NULL } };
   //! Pipeline step responsible for compresssing/writing unidentified 2 reads
   size_t unidentified_2_step = disabled;
 

--- a/src/userconfig.cpp
+++ b/src/userconfig.cpp
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: 2014 Mikkel Schubert <mikkelsch@gmail.com>
 #include "userconfig.hpp"  // declarations
 #include "alignment.hpp"   // for alignment_info
-#include "commontypes.hpp" // for string_vec, ...
+#include "commontypes.hpp" // for string_vec, DEV_STDOUT, DEV_STDERR, ...
 #include "debug.hpp"       // for AR_REQUIRE, AR_FAIL
 #include "errors.hpp"      // for fastq_error
 #include "fastq.hpp"       // for ACGT, ACGT::indices, ACGT::values
@@ -189,8 +189,8 @@ check_no_clobber(const std::string& label,
 void
 normalize_input_file(std::string& filename)
 {
-  if (filename == "-") {
-    filename = "/dev/stdin";
+  if (filename == DEV_PIPE) {
+    filename = DEV_STDIN;
   }
 }
 
@@ -198,8 +198,8 @@ normalize_input_file(std::string& filename)
 void
 normalize_output_file(std::string& filename)
 {
-  if (filename == "-") {
-    filename = "/dev/stdout";
+  if (filename == DEV_PIPE) {
+    filename = DEV_STDOUT;
   }
 }
 
@@ -520,7 +520,7 @@ userconfig::userconfig()
           "was not set [default: not set]")
     .deprecated_alias("--basename")
     .bind_str(&out_prefix)
-    .with_default("/dev/null");
+    .with_default(DEV_NULL);
 
   argparser.add_separator();
   argparser.add("--out-file1", "FILE")
@@ -1356,7 +1356,7 @@ userconfig::can_merge_alignment(const alignment_info& alignment) const
 output_format
 userconfig::infer_output_format(const std::string& filename) const
 {
-  if (filename == "/dev/stdout") {
+  if (filename == DEV_STDOUT) {
     return out_stdout_format;
   }
 


### PR DESCRIPTION
Replaces multiple hardcoded strings like "/dev/stdin" and "-" with a constants
