### PR TITLE
further improvements to build system

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: dependencies (libraries)
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: sudo apt-get install zlib1g-dev libisal-dev libdeflate-dev gcovr
+        run: sudo apt-get install -y libisal-dev libdeflate-dev
 
       - name: dependencies (libraries)
         if: ${{ matrix.os == 'macos-latest' }}
@@ -69,11 +69,8 @@ jobs:
       - name: setup
         run: make setup DEBUG=true SANITIZE=true COVERAGE=${{ matrix.coverage }}
 
-      - name: compile (executable)
-        run: make executable DEBUG=true SANITIZE=true COVERAGE=${{ matrix.coverage }}
-
-      - name: compile (unit tests)
-        run: make test_executable DEBUG=true SANITIZE=true COVERAGE=${{ matrix.coverage }}
+      - name: compile
+        run: make executables DEBUG=true SANITIZE=true COVERAGE=${{ matrix.coverage }}
 
       - name: install
         run: make install DESTDIR=${PWD}/install
@@ -82,17 +79,18 @@ jobs:
         run: make -C examples EXE=${PWD}/build/src/adapterremoval3
 
       - name: regression tests
-        run: make regression
+        run: make regression-tests
 
       # Unit tests are run last to enable cleanup of coverage data from other
       # actions before running coveralls
       - name: unit tests
         run: |
           find . -name '*.gcda' -print -delete
-          make test
+          make unit-tests
 
       - name: coveralls
         if: ${{ matrix.coverage == 'true' && github.event_name == 'push' }}
         run: |
+          sudo apt-get install -y gcovr
           uv pip install cpp-coveralls
           coveralls --exclude tests --root . --build-root build --gcov-options '\-lpbc'

--- a/meson.build
+++ b/meson.build
@@ -7,12 +7,12 @@ project(
     version: '3.0.0-alpha3',
     meson_version: '>=1.2.0',
     default_options: {
-        'buildtype': 'debugoptimized',
+        # Disable costly (libc++) assertions in release mode
+        'b_ndebug': 'true',
         'cpp_std': 'c++17',
+        'debug': 'false',
         'optimization': '2',
         'warning_level': '3',
-        # Disable costly (libc++) assertions in release mode
-        'b_ndebug': 'if-release',
     },
 )
 
@@ -146,24 +146,17 @@ if container_runner.found()
             '-C', '/host/src',
             'BUILDDIR=/host/out/static/build',
             'DESTDIR=/host/out/static/install',
-            'BUILD=@0@'.format(get_option('buildtype')),
+            'DEBUG=@0@'.format(get_option('debug')),
             'COVERAGE=@0@'.format(get_option('b_coverage')),
             # Compilation with sanitize flags fails with alpine 3.20.1, but support is
             # left in to avoid giving the false impression that they were enabled
-            'SANITIZE_OPTS=@0@'.format(get_option('b_sanitize')),
+            'SANITIZE=@0@'.format(get_option('b_sanitize') != 'none'),
             'HARDEN=@0@'.format(get_option('harden')),
             'STATIC=true',
             'MIMALLOC=true',
             'setup',
-            'test',
-            'regression',
+            'tests',
             'install',
         ],
     )
 endif
-
-################################################################################
-
-summary('type', get_option('buildtype'), section: 'Build')
-summary('static', static, section: 'Build')
-summary('harden', harden, section: 'Build')

--- a/src/meson.build
+++ b/src/meson.build
@@ -57,7 +57,7 @@ libsimd_config = {
 }
 
 foreach key, simd_config : libsimd_config
-    summary(simd_config[0], config.get(key) != '0', section: 'SIMD')
+    summary(simd_config[0], config.get(key) != '0', section: 'Build')
     if config.get(key) != '0'
         libsimd += [
             static_library(
@@ -97,7 +97,7 @@ libcore = static_library(
     'table_reader.cpp',
     'utilities.cpp',
     config_inc,
-    dependencies: [libdeflate, libisal, libmimalloc,  libthreads],
+    dependencies: [libdeflate, libisal, libmimalloc, libthreads],
 )
 
 exe = executable(
@@ -124,6 +124,6 @@ exe = executable(
     html_template,
     config_inc,
     link_with: [libcore, libsimd],
-    dependencies: [libdeflate, libisal, libmimalloc,  libthreads],
+    dependencies: [libdeflate, libisal, libmimalloc, libthreads],
     install: true,
 )

--- a/tests/regression/meson.build
+++ b/tests/regression/meson.build
@@ -12,7 +12,7 @@ else
 endif
 
 custom_target(
-    'regression',
+    'run-regression-tests',
     command: [regression_test_exe]
     + regression_test_args
     + [
@@ -29,7 +29,7 @@ custom_target(
 )
 
 custom_target(
-    'update-regression',
+    'update-regression-tests',
     command: [regression_test_exe]
     + regression_test_args
     + [

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -28,19 +28,13 @@ unit_tests = executable(
     include_directories: [
         '..' / '..' / 'src',
     ],
-    cpp_args: [
-        # Custom function to serialize values; see 'testing.hpp'
-        '-DCATCH_CONFIG_FALLBACK_STRINGIFIER=::Catch::fallbackStringifier',
-    ],
 )
 
-test(
-    'unit_tests',
-    unit_tests,
-    args: [
+run_target(
+    'run-unit-tests',
+    command: [
+        unit_tests,
         '--invisibles',
         '--use-colour', 'yes',
     ],
-    suite: ['unit'],
-    verbose: true,
 )

--- a/tests/unit/testing.hpp
+++ b/tests/unit/testing.hpp
@@ -7,6 +7,9 @@
 #include <string> // for string
 #include <vector> // for vector
 
+#define CATCH_CONFIG_FAST_COMPILE
+#define CATCH_CONFIG_FALLBACK_STRINGIFIER ::Catch::fallbackStringifier
+
 namespace Catch {
 
 /** Helper macro for typed catching of thrown messages */


### PR DESCRIPTION
* rename Makefile targets names for consistency
* add target for building executables simultanously, to improve speed
* enable debug build by default for coverage build
* fix n_debug being set inconsistently
* drop setting build-type and instead just set debug
* re-merge compilation in workflow
* make unit tests a run_target, since there's only one executable
* enable fast compile for Catch2
* minor cleanup of build/test workflow