### PR TITLE
Revert "drop support for '.' as 'N' in FASTQ reads"

### DIFF
--- a/src/fastq_enc.cpp
+++ b/src/fastq_enc.cpp
@@ -267,7 +267,12 @@ process_nucleotides_strict(std::string& nucleotides)
         break;
 
       default:
-        throw_invalid_base(nuc);
+        // Found in some very old data sets
+        if (nuc == '.') {
+          nuc = 'N';
+        } else {
+          throw_invalid_base(nuc);
+        }
     }
   }
 }
@@ -317,7 +322,12 @@ process_nucleotides_lenient(std::string& nucleotides,
         }
 
       default:
-        throw_invalid_base(nuc);
+        if (nuc == '.') {
+          // Found in some very old data sets
+          nuc = 'N';
+        } else {
+          throw_invalid_base(nuc);
+        }
     }
   }
 }

--- a/tests/unit/fastq_test.cpp
+++ b/tests/unit/fastq_test.cpp
@@ -141,6 +141,16 @@ TEST_CASE("constructor_simple_record_lowercase_to_uppercase", "[fastq::fastq]")
   REQUIRE(record.sequence() == "ANGAGTCA");
 }
 
+TEST_CASE("constructor_simple_record_dots_to_n", "[fastq::fastq]")
+{
+  const auto degenerate_bases =
+    GENERATE(degenerate_encoding::mask, degenerate_encoding::reject);
+  const auto encoding = fastq_encoding(quality_encoding::sam, degenerate_bases);
+
+  const fastq record("record_1", "AC.AG.C.", "!7BF8DGI", encoding);
+  REQUIRE(record.sequence() == "ACNAGNCN");
+}
+
 TEST_CASE("constructor_score_boundaries_phred_33", "[fastq::fastq]")
 {
   REQUIRE_NOTHROW(fastq("Rec", "CAT", "!!\"", FASTQ_ENCODING_33));


### PR DESCRIPTION
This reverts commit d3814465fd0b8bd45bd6cf86a1d07ce430353b3a. This fixes #112