### PR TITLE
update coverage configuration

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -98,7 +98,14 @@ jobs:
         run: |
           sudo apt-get install -y gcovr
           uv pip install cpp-coveralls
-          coveralls --exclude tests --root . --build-root build --gcov-options '\-lpbc'
+          coveralls \
+            --exclude build/src/reports_template_html.cpp \
+            --exclude build/src/reports_template_html.hpp \
+            --exclude src/robin_hood.hpp \
+            --exclude tests/unit/catch.hpp \
+            --build-root build \
+            --root . \
+            --gcov-options '\-lpbc'
 
       - name: CCache cleanup
       # Manual ccache cleanup, using the ccache-action default max size

--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -1,0 +1,6 @@
+exclude = build/src/*.*pp
+exclude = tests/unit/catch.hpp
+exclude = src/robin_hood.hpp
+exclude-unreachable-branches = yes
+exclude-throw-branches = yes
+exclude-lines-by-pattern = .*\s+AR_FAIL\(.*


### PR DESCRIPTION
exclude generated code, third party code, and uninformative lines / branches from coverage analysis