### PR TITLE
replace default catch2 string rendering

### DIFF
--- a/tests/unit/catch.hpp
+++ b/tests/unit/catch.hpp
@@ -15086,6 +15086,8 @@ std::string fpToString( T value, int precision ) {
 //
 //// ======================================================= ////
 
+// Does not handle non-printable characters
+#if 0
 std::string StringMaker<std::string>::convert(const std::string& str) {
     if (!getCurrentContext().getConfig()->showInvisibles()) {
         return '"' + str + '"';
@@ -15108,6 +15110,7 @@ std::string StringMaker<std::string>::convert(const std::string& str) {
     s.append("\"");
     return s;
 }
+#endif
 
 #ifdef CATCH_CONFIG_CPP17_STRING_VIEW
 std::string StringMaker<std::string_view>::convert(std::string_view str) {

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -39,7 +39,6 @@ run_target(
     'run-unit-tests',
     command: [
         unit_tests,
-        '--invisibles',
         '--use-colour', 'yes',
     ],
 )

--- a/tests/unit/testing.cpp
+++ b/tests/unit/testing.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Mikkel Schubert <mikkelsch@gmail.com>
 #include "testing.hpp"  // declarations
 #include "strutils.hpp" // for log_escape
+#include <cctype>       // for isprint
 
 namespace {
 
@@ -22,6 +23,23 @@ Catch::StringMaker<std::invalid_argument, void>::convert(
   const std::invalid_argument& value)
 {
   return format_exception("invalid_argument", value);
+}
+
+std::string
+StringMaker<std::string>::convert(const std::string& str)
+{
+  if (getCurrentContext().getConfig()->showInvisibles()) {
+    return adapterremoval::log_escape(str);
+  }
+
+  for (const auto c : str) {
+    // Escape any special characters that cannot be distinguished at a glance
+    if (!std::isprint(c) || (std::isspace(c) && (c != ' ' && c != '\n'))) {
+      return adapterremoval::log_escape(str);
+    }
+  }
+
+  return '"' + str + '"';
 }
 
 } // namespace Catch


### PR DESCRIPTION
Detect if strings contain unprintable characters or whitespace that cannot easily be distinguished, and escape everything if that is the case