### PR TITLE
rework add meta-data class for read serialization

### DIFF
--- a/src/commontypes.hpp
+++ b/src/commontypes.hpp
@@ -51,6 +51,14 @@ enum class read_type
   pe_2,
   //! PE mate 1 read that failed QC
   pe_2_fail,
+  //! PE mate 1 read for which the mate 2 read failed QC
+  singleton_1,
+  //! PE mate 2 read for which the mate 1 read failed QC
+  singleton_2,
+  //! Merged PE reads
+  merged,
+  //! Merged PE reads that failed QC
+  merged_fail,
 };
 
 /** Enum describing the user-requested output format for processed reads */

--- a/src/demultiplexing.cpp
+++ b/src/demultiplexing.cpp
@@ -7,7 +7,6 @@
 #include "fastq_io.hpp"      // for chunk_ptr, fastq...
 #include "output.hpp"        // for output_files
 #include "sequence_sets.hpp" // for adapter_set
-#include "serializer.hpp"    // for read_type
 #include "userconfig.hpp"    // for userconfig, ar_command, ar_command::demul...
 #include <cstddef>           // for size_t
 #include <memory>            // for make_unique, unique_ptr
@@ -183,18 +182,18 @@ process_demultiplexed::process(chunk_ptr chunk)
     for (; it_1 != chunk->reads_1.end(); ++it_1, ++it_2, ++barcode) {
       it_1->add_prefix_to_name(m_config.prefix_read_1);
       stats->read_1->process(*it_1);
-      chunks.add(*it_1, read_file::mate_1, read_type::pe_1, *barcode);
+      chunks.add(std::move(*it_1), read_type::pe_1, *barcode);
 
       it_2->add_prefix_to_name(m_config.prefix_read_2);
       stats->read_2->process(*it_2);
-      chunks.add(*it_2, read_file::mate_2, read_type::pe_2, *barcode);
+      chunks.add(std::move(*it_2), read_type::pe_2, *barcode);
     }
   } else {
     for (auto& read : chunk->reads_1) {
       read.add_prefix_to_name(m_config.prefix_read_1);
 
       stats->read_1->process(read);
-      chunks.add(read, read_file::mate_1, read_type::se, *barcode++);
+      chunks.add(std::move(read), read_type::se, *barcode++);
     }
   }
 
@@ -258,18 +257,18 @@ processes_unidentified::process(chunk_ptr chunk)
     for (; it_1 != chunk->reads_1.end(); ++it_1, ++it_2) {
       it_1->add_prefix_to_name(m_config.prefix_read_1);
       stats_1->process(*it_1);
-      chunks.add(*it_1, read_file::mate_1, read_type::pe_1, 0);
+      chunks.add(std::move(*it_1), read_type::pe_1);
 
       it_2->add_prefix_to_name(m_config.prefix_read_2);
       stats_2->process(*it_2);
-      chunks.add(*it_2, read_file::mate_2, read_type::pe_2, 0);
+      chunks.add(std::move(*it_2), read_type::pe_2);
     }
   } else {
     for (auto& read : chunk->reads_1) {
       read.add_prefix_to_name(m_config.prefix_read_1);
 
       stats_1->process(read);
-      chunks.add(read, read_file::mate_1, read_type::se, 0);
+      chunks.add(std::move(read), read_type::se);
     }
   }
 

--- a/src/demultiplexing.cpp
+++ b/src/demultiplexing.cpp
@@ -182,18 +182,18 @@ process_demultiplexed::process(chunk_ptr chunk)
     for (; it_1 != chunk->reads_1.end(); ++it_1, ++it_2, ++barcode) {
       it_1->add_prefix_to_name(m_config.prefix_read_1);
       stats->read_1->process(*it_1);
-      chunks.add(std::move(*it_1), read_type::pe_1, *barcode);
+      chunks.add(*it_1, read_type::pe_1, *barcode);
 
       it_2->add_prefix_to_name(m_config.prefix_read_2);
       stats->read_2->process(*it_2);
-      chunks.add(std::move(*it_2), read_type::pe_2, *barcode);
+      chunks.add(*it_2, read_type::pe_2, *barcode);
     }
   } else {
     for (auto& read : chunk->reads_1) {
       read.add_prefix_to_name(m_config.prefix_read_1);
 
       stats->read_1->process(read);
-      chunks.add(std::move(read), read_type::se, *barcode++);
+      chunks.add(read, read_type::se, *barcode++);
     }
   }
 
@@ -257,18 +257,18 @@ processes_unidentified::process(chunk_ptr chunk)
     for (; it_1 != chunk->reads_1.end(); ++it_1, ++it_2) {
       it_1->add_prefix_to_name(m_config.prefix_read_1);
       stats_1->process(*it_1);
-      chunks.add(std::move(*it_1), read_type::pe_1);
+      chunks.add(*it_1, read_type::pe_1);
 
       it_2->add_prefix_to_name(m_config.prefix_read_2);
       stats_2->process(*it_2);
-      chunks.add(std::move(*it_2), read_type::pe_2);
+      chunks.add(*it_2, read_type::pe_2);
     }
   } else {
     for (auto& read : chunk->reads_1) {
       read.add_prefix_to_name(m_config.prefix_read_1);
 
       stats_1->process(read);
-      chunks.add(std::move(read), read_type::se);
+      chunks.add(read, read_type::se);
     }
   }
 

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -87,6 +87,11 @@ parsing_error::parsing_error(const std::string& message)
 {
 }
 
+serializing_error::serializing_error(const std::string& message)
+  : std::runtime_error(message)
+{
+}
+
 fastq_error::fastq_error(const std::string& message)
   : parsing_error(message)
 {

--- a/src/errors.hpp
+++ b/src/errors.hpp
@@ -42,6 +42,13 @@ public:
   explicit parsing_error(const std::string& message);
 };
 
+/** Exception raised for for errors during serialization / encoding. */
+class serializing_error : public std::runtime_error
+{
+public:
+  explicit serializing_error(const std::string& message);
+};
+
 /** Exception raised for FASTQ parsing and validation errors. */
 class fastq_error : public parsing_error
 {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -240,12 +240,12 @@ processed_reads::write_headers(const string_vec& args)
 }
 
 void
-processed_reads::add(fastq&& read, const read_meta& meta)
+processed_reads::add(const fastq& read, const read_meta& meta)
 {
   const size_t offset = m_map.offset(meta.get_file());
   if (offset != sample_output_files::disabled) {
     auto& buffer = get_buffer(m_chunks.at(offset));
-    m_serializers.at(offset).record(buffer, std::move(read), meta);
+    m_serializers.at(offset).record(buffer, read, meta);
     m_chunks.at(offset)->reads++;
   }
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -6,7 +6,7 @@
 #include "fastq.hpp"      // for fastq
 #include "fastq_io.hpp"   // for write_fastq, split_fastq, gzip_split_fastq
 #include "scheduler.hpp"  // for analytical_chunk
-#include "serializer.hpp" // for fastq_serializer
+#include "serializer.hpp" // for read_meta
 #include "strutils.hpp"   // for ends_with
 #include <limits>         // for numeric_limits
 
@@ -240,15 +240,12 @@ processed_reads::write_headers(const string_vec& args)
 }
 
 void
-processed_reads::add(const fastq& read,
-                     const read_file type,
-                     const read_type flags,
-                     const size_t barcode)
+processed_reads::add(fastq&& read, const read_meta& meta)
 {
-  const size_t offset = m_map.offset(type);
+  const size_t offset = m_map.offset(meta.get_file());
   if (offset != sample_output_files::disabled) {
     auto& buffer = get_buffer(m_chunks.at(offset));
-    m_serializers.at(offset).record(buffer, read, flags, barcode);
+    m_serializers.at(offset).record(buffer, std::move(read), meta);
     m_chunks.at(offset)->reads++;
   }
 }

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "commontypes.hpp" // for string_vec, read_file, merge_strategy, ...
-#include "serializer.hpp"  // for serializer
+#include "serializer.hpp"  // for serializer, read_meta, read_type
 #include <array>           // for array
 #include <cstddef>         // for size_t
 #include <memory>          // for unique_ptr
@@ -166,8 +166,14 @@ public:
   /** Writes any headers required by the output format  */
   void write_headers(const string_vec& args);
 
+  /** Adds a read of the given type to be processed with simple meta-data */
+  void add(fastq&& read, read_type flags, size_t barcode = 0)
+  {
+    add(std::move(read), read_meta(flags).barcode(barcode));
+  }
+
   /** Adds a read of the given type to be processed */
-  void add(const fastq& read, read_file type, read_type flags, size_t barcode);
+  void add(fastq&& read, const read_meta& meta);
 
   /** Returns a chunk for each generated type of processed reads. */
   chunk_vec finalize(bool eof);

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -167,13 +167,13 @@ public:
   void write_headers(const string_vec& args);
 
   /** Adds a read of the given type to be processed with simple meta-data */
-  void add(fastq&& read, read_type flags, size_t barcode = 0)
+  void add(const fastq& read, read_type flags, size_t barcode = 0)
   {
-    add(std::move(read), read_meta(flags).barcode(barcode));
+    add(read, read_meta(flags).barcode(barcode));
   }
 
   /** Adds a read of the given type to be processed */
-  void add(fastq&& read, const read_meta& meta);
+  void add(const fastq& read, const read_meta& meta);
 
   /** Returns a chunk for each generated type of processed reads. */
   chunk_vec finalize(bool eof);

--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -348,7 +348,7 @@ serializer::header(buffer& buf, const string_vec& args) const
 }
 
 void
-serializer::record(buffer& buf, fastq&& record, read_meta meta) const
+serializer::record(buffer& buf, const fastq& record, read_meta meta) const
 {
   const auto& sequences = m_sample.at(meta.m_barcode);
   switch (m_format) {

--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -1,16 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2024 Mikkel Schubert <mikkelsch@gmail.com>
-#include "serializer.hpp"  // for fastq_serializer
+#include "serializer.hpp"  // declarations
 #include "buffer.hpp"      // for buffer
 #include "commontypes.hpp" // for output_format
 #include "debug.hpp"       // for AR_REQUIRE, AR_FAIL
+#include "errors.hpp"      // for serializing_error
 #include "fastq.hpp"       // for fastq
 #include "fastq_enc.hpp"   // for PHRED_OFFSET_MIN
 #include "main.hpp"        // for VERSION
 #include "strutils.hpp"    // for join_text
+#include <sstream>         // for ostringstream
 #include <string_view>     // for string_view
 
 namespace adapterremoval {
+
+using namespace std::literals;
 
 class userconfig;
 
@@ -33,44 +37,52 @@ constexpr std::string_view SAM_HEADER = "@HD\tVN:1.6\tSO:unsorted\n";
  */
 
 std::string_view
-flags_to_sam(read_type flags)
+read_type_to_sam(read_type flags)
 {
   switch (flags) {
     case read_type::se:
+    case read_type::merged:
       return "4";
     case read_type::se_fail:
+    case read_type::merged_fail:
       return "516";
     case read_type::pe_1:
+    case read_type::singleton_1:
       return "77";
     case read_type::pe_1_fail:
       return "589";
     case read_type::pe_2:
+    case read_type::singleton_2:
       return "141";
     case read_type::pe_2_fail:
       return "653";
-    default:
-      AR_FAIL("invalid fastq flags");
+    default:                          // GCOVR_EXCL_LINE
+      AR_FAIL("invalid fastq flags"); // GCOVR_EXCL_LINE
   }
 }
 
 uint16_t
-flags_to_bam(read_type flags)
+read_type_to_bam(read_type flags)
 {
   switch (flags) {
     case read_type::se:
+    case read_type::merged:
       return 4;
     case read_type::se_fail:
+    case read_type::merged_fail:
       return 516;
     case read_type::pe_1:
+    case read_type::singleton_1:
       return 77;
     case read_type::pe_1_fail:
       return 589;
     case read_type::pe_2:
+    case read_type::singleton_2:
       return 141;
     case read_type::pe_2_fail:
       return 653;
-    default:
-      AR_FAIL("invalid fastq flags");
+    default:                          // GCOVR_EXCL_LINE
+      AR_FAIL("invalid fastq flags"); // GCOVR_EXCL_LINE
   }
 }
 
@@ -127,26 +139,44 @@ create_sam_header(const string_vec& args, const sample& s)
   return header;
 }
 
+std::string_view
+prepare_name(const fastq& record, const char mate_separator)
+{
+  auto name = record.name(mate_separator);
+  if (name.length() > 254) {
+    std::ostringstream os;
+    os << "Cannot encode read as SAM/BAM; read name is longer than 254 "
+       << "characters: len(" << log_escape(name) << ") == " << name.length();
+
+    throw serializing_error(os.str());
+  }
+
+  for (const char c : name) {
+    if ((c < '!' || c > '?') && (c < 'A' || c > '~')) {
+      std::ostringstream os;
+      os << "Cannot encode read as SAM/BAM; read name contains characters "
+         << "other than the allowed [!-?A-~]: " << log_escape(name);
+
+      throw serializing_error(os.str());
+    }
+  }
+
+  return name;
+}
+
 } // namespace
 
 ///////////////////////////////////////////////////////////////////////////////
 // Implementations for `fastq_serializer`
 
 void
-fastq_serializer::header(buffer& /* buf */,
-                         const string_vec& /* args */,
-                         const sample& /* s */)
-{
-}
-
-void
-fastq_serializer::record(buffer& buf,
+serializer::fastq_record(buffer& buf,
                          const fastq& record,
-                         const sample_sequences& sequences,
-                         const serializer_settings& settings)
+                         const read_meta& /* meta */,
+                         const sample_sequences& sequences) const
 {
   buf.append(record.header());
-  if (settings.demultiplexing_only) {
+  if (m_demultiplexing_only && !sequences.barcode_1.empty()) {
     buf.append(" BC:");
     buf.append(sequences.barcode_1);
     if (sequences.barcode_2.length()) {
@@ -156,7 +186,7 @@ fastq_serializer::record(buffer& buf,
   }
   buf.append_u8('\n');
   buf.append(record.sequence());
-  buf.append("\n+\n", 3);
+  buf.append("\n+\n"sv);
   buf.append(record.qualities());
   buf.append_u8('\n');
 }
@@ -165,20 +195,20 @@ fastq_serializer::record(buffer& buf,
 // Implementations for `sam_serializer`
 
 void
-sam_serializer::header(buffer& buf, const string_vec& args, const sample& s)
+serializer::sam_header(buffer& buf, const string_vec& args, const sample& s)
 {
   buf.append(create_sam_header(args, s));
 }
 
 void
-sam_serializer::record(buffer& buf,
+serializer::sam_record(buffer& buf,
                        const fastq& record,
-                       const sample_sequences& sequences,
-                       const serializer_settings& settings)
+                       const read_meta& meta,
+                       const sample_sequences& sequences) const
 {
-  buf.append(record.name(settings.mate_separator)); // 1. QNAME
+  buf.append(prepare_name(record, m_mate_separator)); // 1. QNAME
   buf.append_u8('\t');
-  buf.append(flags_to_sam(settings.flags)); // 2. FLAG
+  buf.append(read_type_to_sam(meta.m_type)); // 2. FLAG
   buf.append("\t"
              "*\t" // 3. RNAME
              "0\t" // 4. POS
@@ -188,6 +218,7 @@ sam_serializer::record(buffer& buf,
              "0\t" // 8. PNEXT
              "0\t" // 9. TLEN
   );
+
   if (record.length()) {
     buf.append(record.sequence()); // 10. SEQ
     buf.append_u8('\t');
@@ -210,7 +241,7 @@ sam_serializer::record(buffer& buf,
 // Implementations for `bam_serializer`
 
 void
-bam_serializer::header(buffer& buf, const string_vec& args, const sample& s)
+serializer::bam_header(buffer& buf, const string_vec& args, const sample& s)
 {
   const auto sam_header = create_sam_header(args, s);
 
@@ -221,22 +252,22 @@ bam_serializer::header(buffer& buf, const string_vec& args, const sample& s)
 }
 
 void
-bam_serializer::record(buffer& buf,
+serializer::bam_record(buffer& buf,
                        const fastq& record,
-                       const sample_sequences& sequences,
-                       const serializer_settings& settings)
+                       const read_meta& meta,
+                       const sample_sequences& sequences) const
 {
   const size_t block_size_pos = buf.size();
   buf.append_u32(0);  // block size (preliminary)
   buf.append_i32(-1); // refID
   buf.append_i32(-1); // pos
 
-  const auto name = record.name(settings.mate_separator).substr(0, 255);
+  const auto name = prepare_name(record, m_mate_separator);
   buf.append_u8(name.length() + 1); // l_read_name
   buf.append_u8(0);                 // mapq
   buf.append_u16(4680);             // bin (c.f. specification 4.2.1)
   buf.append_u16(0);                // n_cigar
-  buf.append_u16(flags_to_bam(settings.flags)); // flags
+  buf.append_u16(read_type_to_bam(meta.m_type)); // flags
 
   buf.append_u32(record.length()); // l_seq
   buf.append_i32(-1);              // next_refID
@@ -261,48 +292,81 @@ bam_serializer::record(buffer& buf,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// Implementations for `read_meta`
+
+read_file
+read_meta::get_file() const noexcept
+{
+  switch (m_type) {
+    case read_type::se:
+    case read_type::pe_1:
+      return read_file::mate_1;
+    case read_type::pe_2:
+      return read_file::mate_2;
+    case read_type::se_fail:
+    case read_type::pe_1_fail:
+    case read_type::pe_2_fail:
+    case read_type::merged_fail:
+      return read_file::discarded;
+    case read_type::singleton_1:
+    case read_type::singleton_2:
+      return read_file::singleton;
+    case read_type::merged:
+      return read_file::merged;
+    default:                         // GCOVR_EXCL_LINE
+      AR_FAIL("invalid read flags"); // GCOVR_EXCL_LINE
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // Implementations for `serializer`
 
 serializer::serializer(output_format format)
+  : m_format(format)
 {
-  switch (format) {
-    case output_format::fastq:
-    case output_format::fastq_gzip:
-      m_header = fastq_serializer::header;
-      m_record = fastq_serializer::record;
-      break;
-    case output_format::sam:
-    case output_format::sam_gzip:
-      m_header = sam_serializer::header;
-      m_record = sam_serializer::record;
-      break;
-    case output_format::bam:
-    case output_format::ubam:
-      m_header = bam_serializer::header;
-      m_record = bam_serializer::record;
-      break;
-    default:
-      AR_FAIL("invalid output format");
-  }
 }
 
 void
 serializer::header(buffer& buf, const string_vec& args) const
 {
-  m_header(buf, args, m_sample);
+  switch (m_format) {
+    case output_format::fastq:
+    case output_format::fastq_gzip:
+      // No header
+      break;
+    case output_format::sam:
+    case output_format::sam_gzip:
+      sam_header(buf, args, m_sample);
+      break;
+    case output_format::bam:
+    case output_format::ubam:
+      bam_header(buf, args, m_sample);
+      break;
+    default:                            // GCOVR_EXCL_LINE
+      AR_FAIL("invalid output format"); // GCOVR_EXCL_LINE
+  }
 }
 
 void
-serializer::record(buffer& buf,
-                   const fastq& record,
-                   const read_type flags,
-                   const size_t barcode) const
+serializer::record(buffer& buf, fastq&& record, read_meta meta) const
 {
-  m_record(
-    buf,
-    record,
-    m_sample.at(barcode),
-    serializer_settings{ flags, m_mate_separator, m_demultiplexing_only });
+  const auto& sequences = m_sample.at(meta.m_barcode);
+  switch (m_format) {
+    case output_format::fastq:
+    case output_format::fastq_gzip:
+      fastq_record(buf, record, meta, sequences);
+      break;
+    case output_format::sam:
+    case output_format::sam_gzip:
+      sam_record(buf, record, meta, sequences);
+      break;
+    case output_format::bam:
+    case output_format::ubam:
+      bam_record(buf, record, meta, sequences);
+      break;
+    default:                            // GCOVR_EXCL_LINE
+      AR_FAIL("invalid output format"); // GCOVR_EXCL_LINE
+  }
 }
 
 } // namespace adapterremoval

--- a/src/serializer.hpp
+++ b/src/serializer.hpp
@@ -60,7 +60,7 @@ public:
   void set_demultiplexing_only(bool value) { m_demultiplexing_only = value; }
 
   void header(buffer& buf, const string_vec& args) const;
-  void record(buffer& buf, fastq&& record, read_meta meta) const;
+  void record(buffer& buf, const fastq& record, read_meta meta) const;
 
 private:
   /** Write record to buffer in in FASTQ format */

--- a/src/serializer.hpp
+++ b/src/serializer.hpp
@@ -2,10 +2,9 @@
 // SPDX-FileCopyrightText: 2024 Mikkel Schubert <mikkelsch@gmail.com>
 #pragma once
 
-#include "commontypes.hpp"   // for string_vec
+#include "commontypes.hpp"   // for string_vec, read_type, read_file
 #include "sequence_sets.hpp" // for sample
 #include <cstddef>           // for size_t
-#include <functional>        // for function
 
 namespace adapterremoval {
 
@@ -14,42 +13,39 @@ class fastq;
 class read_group;
 enum class output_format;
 
-/** Struct containing metadata required to serialize a record */
-struct serializer_settings
-{
-  const read_type flags = read_type::se;
-  const char mate_separator = '\0';
-  const bool demultiplexing_only = false;
-};
-
-class fastq_serializer
+/** Class for recording meta-information about reads for serialization */
+class read_meta
 {
 public:
-  static void header(buffer& buf, const string_vec& args, const sample& s);
-  static void record(buffer& buf,
-                     const fastq& record,
-                     const sample_sequences& sequences,
-                     const serializer_settings& settings);
-};
+  /** Creates read meta-data for the specified read type */
+  constexpr explicit read_meta(read_type type)
+    : m_type(type)
+  {
+  }
 
-class sam_serializer
-{
-public:
-  static void header(buffer& buf, const string_vec& args, const sample& s);
-  static void record(buffer& buf,
-                     const fastq& record,
-                     const sample_sequences& sequences,
-                     const serializer_settings& settings);
-};
+  /** Returns the file type associated with the read type */
+  [[nodiscard]] read_file get_file() const noexcept;
 
-class bam_serializer
-{
-public:
-  static void header(buffer& buf, const string_vec& args, const sample& s);
-  static void record(buffer& buf,
-                     const fastq& record,
-                     const sample_sequences& sequences,
-                     const serializer_settings& settings);
+  /** Overwrites the current read type */
+  constexpr auto& type(read_type v) noexcept
+  {
+    m_type = v;
+    return *this;
+  }
+
+  /** Overwrites the current barcode */
+  constexpr auto& barcode(size_t v) noexcept
+  {
+    m_barcode = v;
+    return *this;
+  }
+
+private:
+  friend class serializer;
+
+  read_type m_type{};
+  //! The barcode for this sample; 0 is also used if not demultiplexing
+  size_t m_barcode{};
 };
 
 class serializer
@@ -67,22 +63,37 @@ public:
   void set_demultiplexing_only(bool value) { m_demultiplexing_only = value; }
 
   void header(buffer& buf, const string_vec& args) const;
-  void record(buffer& buf,
-              const fastq& record,
-              read_type flags,
-              size_t barcode) const;
+  void record(buffer& buf, fastq&& record, read_meta meta) const;
 
 private:
+  /** Write record to buffer in in FASTQ format */
+  void fastq_record(buffer& buf,
+                    const fastq& record,
+                    const read_meta& meta,
+                    const sample_sequences& sequences) const;
+
+  /** Write header to buffer in in SAM format */
+  static void sam_header(buffer& buf, const string_vec& args, const sample& s);
+  void sam_record(buffer& buf,
+                  const fastq& record,
+                  const read_meta& meta,
+                  const sample_sequences& sequences) const;
+
+  /** Write header to buffer in in BAM format (uncompressed) */
+  static void bam_header(buffer& buf, const string_vec& args, const sample& s);
+  void bam_record(buffer& buf,
+                  const fastq& record,
+                  const read_meta& meta,
+                  const sample_sequences& sequences) const;
+
+  //! User specified output format
+  output_format m_format = output_format::fastq;
   //! Sample information to be added to SAM/BAM records
   sample m_sample{};
   //! Mate separator in processed reads
   char m_mate_separator = '\0';
   //! Indicates if output has only been demultiplexed but not trimmed
   bool m_demultiplexing_only = false;
-  //! Function used to serialize file headers for processed reads
-  std::function<decltype(fastq_serializer::header)> m_header{};
-  //! Function used to serialize processed reads
-  std::function<decltype(fastq_serializer::record)> m_record{};
 };
 
 } // namespace adapterremoval

--- a/src/serializer.hpp
+++ b/src/serializer.hpp
@@ -5,6 +5,7 @@
 #include "commontypes.hpp"   // for string_vec, read_type, read_file
 #include "sequence_sets.hpp" // for sample
 #include <cstddef>           // for size_t
+#include <iosfwd>            // for ostream
 
 namespace adapterremoval {
 
@@ -26,19 +27,15 @@ public:
   /** Returns the file type associated with the read type */
   [[nodiscard]] read_file get_file() const noexcept;
 
-  /** Overwrites the current read type */
-  constexpr auto& type(read_type v) noexcept
-  {
-    m_type = v;
-    return *this;
-  }
-
   /** Overwrites the current barcode */
   constexpr auto& barcode(size_t v) noexcept
   {
     m_barcode = v;
     return *this;
   }
+
+  /** Creates debug representation of read meta data */
+  friend std::ostream& operator<<(std::ostream& os, const read_meta& value);
 
 private:
   friend class serializer;
@@ -95,5 +92,9 @@ private:
   //! Indicates if output has only been demultiplexed but not trimmed
   bool m_demultiplexing_only = false;
 };
+
+/** Creates debug representation of read meta data */
+std::ostream&
+operator<<(std::ostream& os, const read_file& value);
 
 } // namespace adapterremoval

--- a/src/trimming.cpp
+++ b/src/trimming.cpp
@@ -569,14 +569,14 @@ pe_reads_processor::process(chunk_ptr chunk)
     read_meta meta_2{ read_type::pe_2 };
     if (!is_ok_1 || !is_ok_2) {
       if (is_ok_1) {
-        meta_1.type(read_type::singleton_1);
-        meta_2.type(read_type::pe_2_fail);
+        meta_1 = read_meta{ read_type::singleton_1 };
+        meta_2 = read_meta{ read_type::pe_2_fail };
       } else if (is_ok_2) {
-        meta_1.type(read_type::pe_1_fail);
-        meta_2.type(read_type::singleton_2);
+        meta_1 = read_meta{ read_type::pe_1_fail };
+        meta_2 = read_meta{ read_type::singleton_2 };
       } else {
-        meta_1.type(read_type::pe_1_fail);
-        meta_2.type(read_type::pe_2_fail);
+        meta_1 = read_meta{ read_type::pe_1_fail };
+        meta_2 = read_meta{ read_type::pe_2_fail };
       }
     }
 

--- a/src/trimming.cpp
+++ b/src/trimming.cpp
@@ -369,10 +369,10 @@ se_reads_processor::process(chunk_ptr chunk)
 
     if (is_acceptable_read(m_config, *stats, read)) {
       stats->read_1->process(read);
-      chunks.add(std::move(read), read_type::se, barcode);
+      chunks.add(read, read_type::se, barcode);
     } else {
       stats->discarded->process(read);
-      chunks.add(std::move(read), read_type::se_fail, barcode);
+      chunks.add(read, read_type::se_fail, barcode);
     }
   }
 
@@ -531,10 +531,10 @@ pe_reads_processor::process(chunk_ptr chunk)
 
         if (is_acceptable_read(m_config, *stats, read_1, 2)) {
           stats->merged->process(read_1, 2);
-          chunks.add(std::move(read_1), read_type::merged, barcode);
+          chunks.add(read_1, read_type::merged, barcode);
         } else {
           stats->discarded->process(read_1, 2);
-          chunks.add(std::move(read_1), read_type::merged_fail, barcode);
+          chunks.add(read_1, read_type::merged_fail, barcode);
         }
 
         continue;
@@ -590,8 +590,8 @@ pe_reads_processor::process(chunk_ptr chunk)
                                    (in_length_2 - read_2.length()));
 
     // Queue reads last, since this result in modifications to lengths
-    chunks.add(std::move(read_1), meta_1.barcode(barcode));
-    chunks.add(std::move(read_2), meta_2.barcode(barcode));
+    chunks.add(read_1, meta_1.barcode(barcode));
+    chunks.add(read_2, meta_2.barcode(barcode));
   }
 
   // Track amount of overlapping bases "lost" due to read merging

--- a/tests/unit/serializer_test.cpp
+++ b/tests/unit/serializer_test.cpp
@@ -94,7 +94,7 @@ TEST_CASE("Writing FASTQ header to buffer", "[serializer::fastq]")
 
   SECTION("basic record")
   {
-    s.record(buf, std::move(record), read_meta{ read_type::se });
+    s.record(buf, record, read_meta{ read_type::se });
     REQUIRE(buf == "@record_1\nACGTACGATA\n+\n!$#$*68CGJ\n"_buffer);
   }
 }
@@ -116,7 +116,7 @@ TEST_CASE("Writing FASTQ records when only demultiplexing")
 
   buffer buf;
   fastq record{ "record_1", "ACGTACGATA", "!$#$*68CGJ" };
-  s.record(buf, std::move(record), read_meta{ read_type::se });
+  s.record(buf, record, read_meta{ read_type::se });
 
   // The read header should include the barcodes when only demultiplexing
   REQUIRE(buf == "@record_1 BC:ACGT-TGCA\nACGTACGATA\n+\n!$#$*68CGJ\n"_buffer);
@@ -131,7 +131,7 @@ TEST_CASE("Writing FASTQ with mate separator")
   s.set_mate_separator(GENERATE('\0', '/'));
 
   buffer buf;
-  s.record(buf, std::move(record), read_meta(read_type::pe_1));
+  s.record(buf, record, read_meta(read_type::pe_1));
   REQUIRE(buf == "@record_1/1\nACGTACGATA\n+\n!$#$*68CGJ\n"_buffer);
 }
 
@@ -164,7 +164,7 @@ TEST_CASE("FASTQ is the same for all read and sub-formats")
 
   const read_meta meta{ type };
   const serializer s{ format };
-  s.record(buf, std::move(record), meta);
+  s.record(buf, record, meta);
 
   REQUIRE(buf == "@record_1\nACGTACGATA\n+\n!$#$*68CGJ\n"_buffer);
 }
@@ -175,7 +175,7 @@ TEST_CASE("Writing empty FASTQ to buffer", "[serializer::fastq]")
   fastq record{ "record_1", "", "" };
 
   serializer s{ output_format::fastq };
-  s.record(buf, std::move(record), read_meta(read_type::se));
+  s.record(buf, record, read_meta(read_type::se));
 
   REQUIRE(buf == "@record_1\n\n+\n\n"_buffer);
 }
@@ -186,7 +186,7 @@ TEST_CASE("Writing FASTQ with meta-data to buffer", "[serializer::fastq]")
   fastq record{ "record_1 length=5", "ACGTA", "68CGJ" };
 
   serializer s{ output_format::fastq };
-  s.record(buf, std::move(record), read_meta(read_type::se));
+  s.record(buf, record, read_meta(read_type::se));
 
   REQUIRE(buf == "@record_1 length=5\nACGTA\n+\n68CGJ\n"_buffer);
 }
@@ -255,7 +255,7 @@ TEST_CASE("serialize SAM record without sample")
   s.set_demultiplexing_only(GENERATE(true, false));
 
   fastq record{ "record", "ACGTACGATA", "!$#$*68CGJ" };
-  s.record(buf, std::move(record), read_meta{ read_type::se });
+  s.record(buf, record, read_meta{ read_type::se });
 
   REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
                  "!$#$*68CGJ\n"_buffer);
@@ -271,7 +271,7 @@ TEST_CASE("serialize SAM record with sample")
 
   buffer buf;
   fastq record{ "record", "ACGTACGATA", "!$#$*68CGJ" };
-  s.record(buf, std::move(record), read_meta{ read_type::se });
+  s.record(buf, record, read_meta{ read_type::se });
 
   REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t!$#$*68CGJ\t"
                  "RG:Z:foo\n"_buffer);
@@ -293,7 +293,7 @@ TEST_CASE("serialize SAM record with multiple barcodes")
 
   SECTION("first/default barcodes")
   {
-    s.record(buf, std::move(record), read_meta{ read_type::se });
+    s.record(buf, record, read_meta{ read_type::se });
     REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t!$#$*68CGJ\t"
                    "RG:Z:foo.1\n"_buffer);
   }
@@ -301,7 +301,7 @@ TEST_CASE("serialize SAM record with multiple barcodes")
   SECTION("second barcodes")
   {
     auto meta = read_meta{ read_type::se }.barcode(1);
-    s.record(buf, std::move(record), meta);
+    s.record(buf, record, meta);
     REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t!$#$*68CGJ\t"
                    "RG:Z:foo.2\n"_buffer);
   }
@@ -316,7 +316,7 @@ TEST_CASE("serialize SAM record with mate separator")
 
   SECTION("without mate sep")
   {
-    s.record(buf, std::move(record), read_meta{ read_type::se });
+    s.record(buf, record, read_meta{ read_type::se });
     REQUIRE(buf == "record/1\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
                    "!$#$*68CGJ\n"_buffer);
   }
@@ -324,7 +324,7 @@ TEST_CASE("serialize SAM record with mate separator")
   SECTION("with mate sep")
   {
     s.set_mate_separator('/');
-    s.record(buf, std::move(record), read_meta{ read_type::se });
+    s.record(buf, record, read_meta{ read_type::se });
     REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
                    "!$#$*68CGJ\n"_buffer);
   }
@@ -339,7 +339,7 @@ TEST_CASE("serialize read types for SAM")
   SECTION("single end")
   {
     s.record(buf,
-             std::move(record),
+             record,
              read_meta{ GENERATE(read_type::se, read_type::merged) });
     REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
                    "!$#$*68CGJ\n"_buffer);
@@ -348,7 +348,7 @@ TEST_CASE("serialize read types for SAM")
   SECTION("single end failed QC")
   {
     s.record(buf,
-             std::move(record),
+             record,
              read_meta{ GENERATE(read_type::se_fail, read_type::merged_fail) });
     REQUIRE(buf == "record\t516\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
                    "!$#$*68CGJ\n"_buffer);
@@ -357,7 +357,7 @@ TEST_CASE("serialize read types for SAM")
   SECTION("paired end mate 1, mate 2 passed/failed")
   {
     s.record(buf,
-             std::move(record),
+             record,
              read_meta{ GENERATE(read_type::pe_1, read_type::singleton_1) });
     REQUIRE(buf == "record\t77\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
                    "!$#$*68CGJ\n"_buffer);
@@ -365,7 +365,7 @@ TEST_CASE("serialize read types for SAM")
 
   SECTION("paired end mate 1 failed, mate 2 passed/failed")
   {
-    s.record(buf, std::move(record), read_meta{ read_type::pe_1_fail });
+    s.record(buf, record, read_meta{ read_type::pe_1_fail });
     REQUIRE(buf == "record\t589\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
                    "!$#$*68CGJ\n"_buffer);
   }
@@ -373,7 +373,7 @@ TEST_CASE("serialize read types for SAM")
   SECTION("paired end mate 2, mate 1 passed/failed")
   {
     s.record(buf,
-             std::move(record),
+             record,
              read_meta{ GENERATE(read_type::pe_2, read_type::singleton_2) });
     REQUIRE(buf == "record\t141\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
                    "!$#$*68CGJ\n"_buffer);
@@ -381,7 +381,7 @@ TEST_CASE("serialize read types for SAM")
 
   SECTION("paired end mate 2 failed, mate 1 passed/failed")
   {
-    s.record(buf, std::move(record), read_meta{ read_type::pe_2_fail });
+    s.record(buf, record, read_meta{ read_type::pe_2_fail });
     REQUIRE(buf == "record\t653\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
                    "!$#$*68CGJ\n"_buffer);
   }
@@ -393,7 +393,7 @@ TEST_CASE("serialize empty SAM record")
 
   buffer buf;
   serializer s{ GENERATE(output_format::sam, output_format::sam_gzip) };
-  s.record(buf, std::move(record), read_meta{ read_type::se });
+  s.record(buf, record, read_meta{ read_type::se });
 
   REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\t*\t*\n"_buffer);
 }
@@ -404,7 +404,7 @@ TEST_CASE("serialize SAM record from FASTQ with meta-data")
   serializer s{ GENERATE(output_format::sam, output_format::sam_gzip) };
 
   fastq record{ "record length=NA", "ACGTACGATA", "!$#$*68CGJ" };
-  s.record(buf, std::move(record), read_meta{ read_type::se });
+  s.record(buf, record, read_meta{ read_type::se });
 
   // The meta-data is (currently) not serialized
   REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
@@ -482,7 +482,7 @@ TEST_CASE("serialize BAM record without sample")
   s.set_demultiplexing_only(GENERATE(true, false));
 
   fastq record{ "record", "ACGTACGATA", "!$#$*68CGJ" };
-  s.record(buf, std::move(record), read_meta{ read_type::se });
+  s.record(buf, record, read_meta{ read_type::se });
 
   REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
                  "\x00\x00\x04\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
@@ -497,7 +497,7 @@ TEST_CASE("serialize BAM record with uneven length sequence")
   s.set_demultiplexing_only(GENERATE(true, false));
 
   fastq record{ "record", "ACGTACGAT", "!$#$*68CG" };
-  s.record(buf, std::move(record), read_meta{ read_type::se });
+  s.record(buf, record, read_meta{ read_type::se });
 
   REQUIRE(buf == "5\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
                  "\x00\x00\x04\x00\t\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
@@ -515,7 +515,7 @@ TEST_CASE("serialize BAM record with sample")
 
   buffer buf;
   fastq record{ "record", "ACGTACGATA", "!$#$*68CGJ" };
-  s.record(buf, std::move(record), read_meta{ read_type::se });
+  s.record(buf, record, read_meta{ read_type::se });
 
   REQUIRE(buf == "=\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
                  "\x00\x00\x04\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
@@ -539,7 +539,7 @@ TEST_CASE("serialize BAM record with multiple barcodes")
 
   SECTION("first/default barcodes")
   {
-    s.record(buf, std::move(record), read_meta{ read_type::se });
+    s.record(buf, record, read_meta{ read_type::se });
     REQUIRE(buf == "?\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
                    "\x00\x00\x04\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
                    "\xff\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02"
@@ -549,7 +549,7 @@ TEST_CASE("serialize BAM record with multiple barcodes")
   SECTION("second barcodes")
   {
     auto meta = read_meta{ read_type::se }.barcode(1);
-    s.record(buf, std::move(record), meta);
+    s.record(buf, record, meta);
     REQUIRE(buf == "?\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
                    "\x00\x00\x04\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
                    "\xff\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02"
@@ -566,7 +566,7 @@ TEST_CASE("serialize BAM record with mate separator")
 
   SECTION("without mate sep")
   {
-    s.record(buf, std::move(record), read_meta{ read_type::se });
+    s.record(buf, record, read_meta{ read_type::se });
     REQUIRE(buf == "8\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\t\x00H\x12"
                    "\x00\x00\x04\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
                    "\xff\x00\x00\x00\x00record/1\x00\x12H\x12\x41\x81\x00\x03"
@@ -576,7 +576,7 @@ TEST_CASE("serialize BAM record with mate separator")
   SECTION("with mate sep")
   {
     s.set_mate_separator('/');
-    s.record(buf, std::move(record), read_meta{ read_type::se });
+    s.record(buf, record, read_meta{ read_type::se });
     REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
                    "\x00\x00\x04\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
                    "\xff\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02"
@@ -593,7 +593,7 @@ TEST_CASE("serialize read types for BAM")
   SECTION("single end")
   {
     s.record(buf,
-             std::move(record),
+             record,
              read_meta{ GENERATE(read_type::se, read_type::merged) });
     REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
                    "\x00\x00\x04\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
@@ -604,7 +604,7 @@ TEST_CASE("serialize read types for BAM")
   SECTION("single end failed QC")
   {
     s.record(buf,
-             std::move(record),
+             record,
              read_meta{ GENERATE(read_type::se_fail, read_type::merged_fail) });
     REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
                    "\x00\x00\x04\x02\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
@@ -615,7 +615,7 @@ TEST_CASE("serialize read types for BAM")
   SECTION("paired end mate 1, mate 2 passed/failed")
   {
     s.record(buf,
-             std::move(record),
+             record,
              read_meta{ GENERATE(read_type::pe_1, read_type::singleton_1) });
     REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
                    "\x00\x00M\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff"
@@ -625,7 +625,7 @@ TEST_CASE("serialize read types for BAM")
 
   SECTION("paired end mate 1 failed, mate 2 passed/failed")
   {
-    s.record(buf, std::move(record), read_meta{ read_type::pe_1_fail });
+    s.record(buf, record, read_meta{ read_type::pe_1_fail });
     REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
                    "\x00\x00M\x02\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff"
                    "\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02\x03"
@@ -635,7 +635,7 @@ TEST_CASE("serialize read types for BAM")
   SECTION("paired end mate 2, mate 1 passed/failed")
   {
     s.record(buf,
-             std::move(record),
+             record,
              read_meta{ GENERATE(read_type::pe_2, read_type::singleton_2) });
     REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
                    "\x00\x00\x8d\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
@@ -645,7 +645,7 @@ TEST_CASE("serialize read types for BAM")
 
   SECTION("paired end mate 2 failed, mate 1 passed/failed")
   {
-    s.record(buf, std::move(record), read_meta{ read_type::pe_2_fail });
+    s.record(buf, record, read_meta{ read_type::pe_2_fail });
     REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
                    "\x00\x00\x8d\x02\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
                    "\xff\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02"
@@ -659,7 +659,7 @@ TEST_CASE("serialize empty BAM record")
 
   buffer buf;
   serializer s{ GENERATE(output_format::bam, output_format::ubam) };
-  s.record(buf, std::move(record), read_meta{ read_type::se });
+  s.record(buf, record, read_meta{ read_type::se });
 
   REQUIRE(buf == "'\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
                  "\x00\x00\x04\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
@@ -672,7 +672,7 @@ TEST_CASE("serialize BAM record from FASTQ with meta-data")
   serializer s{ GENERATE(output_format::bam, output_format::ubam) };
 
   fastq record{ "record length=NA", "ACGTACGATA", "!$#$*68CGJ" };
-  s.record(buf, std::move(record), read_meta{ read_type::se });
+  s.record(buf, record, read_meta{ read_type::se });
 
   // The meta-data is (currently) not serialized
   REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
@@ -699,8 +699,8 @@ TEST_CASE("Serializing too long read names")
   SECTION("fastq is always valid")
   {
     serializer s{ GENERATE(output_format::fastq, output_format::fastq_gzip) };
-    CHECK_NOTHROW(s.record(buf, std::move(record_254), meta));
-    CHECK_NOTHROW(s.record(buf, std::move(record_255), meta));
+    CHECK_NOTHROW(s.record(buf, record_254, meta));
+    CHECK_NOTHROW(s.record(buf, record_255, meta));
   }
 
   SECTION("SAM/BAM allows only 254 characters")
@@ -710,8 +710,8 @@ TEST_CASE("Serializing too long read names")
                            output_format::bam,
                            output_format::ubam) };
 
-    CHECK_NOTHROW(s.record(buf, std::move(record_254), meta));
-    REQUIRE_THROWS_WITH(s.record(buf, std::move(record_255), meta),
+    CHECK_NOTHROW(s.record(buf, record_254, meta));
+    REQUIRE_THROWS_WITH(s.record(buf, record_255, meta),
                         Catch::Contains("Cannot encode read as SAM/BAM; read "
                                         "name is longer than 254 characters"));
   }
@@ -726,7 +726,7 @@ TEST_CASE("invalid read names")
   SECTION("FASTQ allows anything")
   {
     serializer s{ GENERATE(output_format::fastq, output_format::fastq_gzip) };
-    CHECK_NOTHROW(s.record(buf, std::move(record), meta));
+    CHECK_NOTHROW(s.record(buf, record, meta));
   }
 
   SECTION("SAM/BAM limits valid characters")
@@ -736,7 +736,7 @@ TEST_CASE("invalid read names")
                            output_format::bam,
                            output_format::ubam) };
 
-    REQUIRE_THROWS_WITH(s.record(buf, std::move(record), meta),
+    REQUIRE_THROWS_WITH(s.record(buf, record, meta),
                         Catch::Contains("Cannot encode read as SAM/BAM; read "
                                         "name contains characters other than "
                                         "the allowed"));

--- a/tests/unit/serializer_test.cpp
+++ b/tests/unit/serializer_test.cpp
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2011 Stinus Lindgreen <stinus@binf.ku.dk>
 // SPDX-FileCopyrightText: 2014 Mikkel Schubert <mikkelsch@gmail.com>
-#include "buffer.hpp"        // for buffer
-#include "commontypes.hpp"   // for fastq_vec
-#include "fastq.hpp"         // for fastq, fastq::ntrimmed, ACGTN, ACGT
-#include "sequence_sets.hpp" // sample_seequences
-#include "serializer.hpp"    // for fastq_serializer
-#include "testing.hpp"       // for TEST_CASE, REQUIRE, ...
+#include "buffer.hpp"      // for buffer
+#include "commontypes.hpp" // for fastq_vec
+#include "fastq.hpp"       // for fastq, fastq::ntrimmed, ACGTN, ACGT
+#include "main.hpp"        // for VERSION
+#include "read_group.hpp"  // for read_group
+#include "sequence.hpp"    // for dna_sequence
+#include "serializer.hpp"  // for serializer
+#include "strutils.hpp"
+#include "testing.hpp" // for TEST_CASE, REQUIRE, ...
+#include <string>      // for string
+#include <string_view> // for string_view
 
 // Ignore nucleotide and quality strings
 // spell-checker:ignoreRegExp /"[!-~]+"/g
@@ -15,35 +20,640 @@
 
 namespace adapterremoval {
 
+namespace {
+
+//! The program version with the leading 'v' removed; e.g. "3.0.1"
+const std::string VERSION_NO_V{ VERSION.substr(1) };
+
+constexpr std::string_view EXTREMELY_LONG_NAME =
+  "123456789-123456789-123456789-123456789-123456789-123456789-123456789-"
+  "123456789-123456789-123456789-123456789-123456789-123456789-123456789-"
+  "123456789-123456789-123456789-123456789-123456789-123456789-123456789-"
+  "123456789-123456789-123456789-123456789-1234";
+
+// Basic named sample with barcodes, but otherwise no special properties
+const sample BASIC_SAMPLE_WITH_BARCODES{ "foo",
+                                         dna_sequence{ "ACGT" },
+                                         dna_sequence{ "TGCA" },
+                                         barcode_orientation::unspecified };
+
+} // namespace
+
 ///////////////////////////////////////////////////////////////////////////////
-// Writing to stream
+// FASTQ header serialization
 
-TEST_CASE("Writing_to_stream_phred_33", "[fastq::fastq]")
+TEST_CASE("Writing FASTQ header to buffer", "[serializer::fastq]")
 {
-  const fastq record = fastq("record_1", "ACGTACGATA", "!$#$*68CGJ");
-  buffer buf;
-  fastq_serializer::record(buf,
-                           record,
-                           sample_sequences{},
-                           serializer_settings{});
+  serializer s{ GENERATE(output_format::fastq, output_format::fastq_gzip) };
 
-  REQUIRE(
-    std::string_view(reinterpret_cast<const char*>(buf.data()), buf.size()) ==
-    "@record_1\nACGTACGATA\n+\n!$#$*68CGJ\n");
+  // Sample information is only used in the case of --demultiplex-only
+  if (GENERATE(true, false)) {
+    auto sample{ BASIC_SAMPLE_WITH_BARCODES };
+
+    // Read-group information is not used for FASTQ records
+    if (GENERATE(true, false)) {
+      sample.set_read_group(read_group{ "SM:my-sample" });
+    }
+
+    s.set_sample(sample);
+  }
+
+  buffer buf;
+
+  SECTION("header")
+  {
+    // since FASTQ has no header, arguments should not matter
+    s.header(buf, { "adapterremoval3", "--blah" });
+    REQUIRE(buf == buffer{});
+  }
+
+  fastq record{ "record_1", "ACGTACGATA", "!$#$*68CGJ" };
+
+  SECTION("basic record")
+  {
+    s.record(buf, std::move(record), read_meta{ read_type::se });
+    REQUIRE(buf == "@record_1\nACGTACGATA\n+\n!$#$*68CGJ\n"_buffer);
+  }
 }
 
-TEST_CASE("Writing_to_stream_phred_33_explicit", "[fastq::fastq]")
-{
-  const fastq record = fastq("record_1", "ACGTACGATA", "!$#$*68CGJ");
-  buffer buf;
-  fastq_serializer::record(buf,
-                           record,
-                           sample_sequences{},
-                           serializer_settings{});
+///////////////////////////////////////////////////////////////////////////////
+// FASTQ record serialization
 
-  REQUIRE(
-    std::string_view(reinterpret_cast<const char*>(buf.data()), buf.size()) ==
-    "@record_1\nACGTACGATA\n+\n!$#$*68CGJ\n");
+TEST_CASE("Writing FASTQ records when only demultiplexing")
+{
+  sample sample{ BASIC_SAMPLE_WITH_BARCODES };
+  // Read-group information is not used for FASTQ records
+  if (GENERATE(true, false)) {
+    sample.set_read_group(read_group{ "SM:my-sample" });
+  }
+
+  serializer s{ output_format::fastq };
+  s.set_sample(sample);
+  s.set_demultiplexing_only(true);
+
+  buffer buf;
+  fastq record{ "record_1", "ACGTACGATA", "!$#$*68CGJ" };
+  s.record(buf, std::move(record), read_meta{ read_type::se });
+
+  // The read header should include the barcodes when only demultiplexing
+  REQUIRE(buf == "@record_1 BC:ACGT-TGCA\nACGTACGATA\n+\n!$#$*68CGJ\n"_buffer);
+}
+
+TEST_CASE("Writing FASTQ with mate separator")
+{
+  fastq record{ "record_1/1", "ACGTACGATA", "!$#$*68CGJ" };
+
+  serializer s{ output_format::fastq };
+  // This shouldn't matter, as mate separators are not removed for FASTQ reads
+  s.set_mate_separator(GENERATE('\0', '/'));
+
+  buffer buf;
+  s.record(buf, std::move(record), read_meta(read_type::pe_1));
+  REQUIRE(buf == "@record_1/1\nACGTACGATA\n+\n!$#$*68CGJ\n"_buffer);
+}
+
+TEST_CASE("FASTQ is the same for all read and sub-formats")
+{
+  const auto type = GENERATE(read_type::se,
+                             read_type::se_fail,
+                             read_type::pe_1,
+                             read_type::pe_1_fail,
+                             read_type::pe_2,
+                             read_type::pe_2_fail,
+                             read_type::singleton_1,
+                             read_type::singleton_2,
+                             read_type::merged,
+                             read_type::merged_fail,
+                             read_type::se,
+                             read_type::se_fail,
+                             read_type::pe_1,
+                             read_type::pe_1_fail,
+                             read_type::pe_2,
+                             read_type::pe_2_fail,
+                             read_type::singleton_1,
+                             read_type::singleton_2,
+                             read_type::merged,
+                             read_type::merged_fail);
+  const auto format = GENERATE(output_format::fastq, output_format::fastq_gzip);
+
+  buffer buf;
+  fastq record{ "record_1", "ACGTACGATA", "!$#$*68CGJ" };
+
+  const read_meta meta{ type };
+  const serializer s{ format };
+  s.record(buf, std::move(record), meta);
+
+  REQUIRE(buf == "@record_1\nACGTACGATA\n+\n!$#$*68CGJ\n"_buffer);
+}
+
+TEST_CASE("Writing empty FASTQ to buffer", "[serializer::fastq]")
+{
+  buffer buf;
+  fastq record{ "record_1", "", "" };
+
+  serializer s{ output_format::fastq };
+  s.record(buf, std::move(record), read_meta(read_type::se));
+
+  REQUIRE(buf == "@record_1\n\n+\n\n"_buffer);
+}
+
+TEST_CASE("Writing FASTQ with meta-data to buffer", "[serializer::fastq]")
+{
+  buffer buf;
+  fastq record{ "record_1 length=5", "ACGTA", "68CGJ" };
+
+  serializer s{ output_format::fastq };
+  s.record(buf, std::move(record), read_meta(read_type::se));
+
+  REQUIRE(buf == "@record_1 length=5\nACGTA\n+\n68CGJ\n"_buffer);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// SAM header serialization
+
+TEST_CASE("Writing SAM header to buffer", "[serializer::fastq]")
+{
+  buffer buf;
+  serializer s{ GENERATE(output_format::sam, output_format::sam_gzip) };
+
+  if (GENERATE(true, false)) {
+    s.set_sample(BASIC_SAMPLE_WITH_BARCODES);
+  }
+
+  s.header(buf, { "adapterremoval3", "--blah" });
+  REQUIRE(buf == "@HD\tVN:1.6\tSO:unsorted\n@PG\tID:adapterremoval\t"
+                 "PN:adapterremoval\tCL:adapterremoval3 --blah\t"
+                 "VN:3.0.0-alpha3\n"_buffer);
+}
+
+TEST_CASE("Writing SAM read-group header to buffer", "[serializer::fastq]")
+{
+  sample sample{ BASIC_SAMPLE_WITH_BARCODES };
+  sample.set_read_group({});
+
+  buffer buf;
+  serializer s{ GENERATE(output_format::sam, output_format::sam_gzip) };
+  s.set_sample(sample);
+
+  s.header(buf, { "adapterremoval3", "--blah" });
+  REQUIRE(buf == "@HD\tVN:1.6\tSO:unsorted\n@RG\tID:foo\tSM:foo\t"
+                 "BC:ACGT-TGCA\n@PG\tID:adapterremoval\t"
+                 "PN:adapterremoval\tCL:adapterremoval3 --blah\t"
+                 "VN:3.0.0-alpha3\n"_buffer);
+}
+
+TEST_CASE("Writing SAM read-group header to buffer with multiple barcodes",
+          "[serializer::fastq]")
+{
+  sample sample{ BASIC_SAMPLE_WITH_BARCODES };
+  sample.add(dna_sequence{ "TTGG" },
+             dna_sequence{ "AGTT" },
+             barcode_orientation::unspecified);
+  sample.set_read_group({});
+
+  buffer buf;
+  serializer s{ GENERATE(output_format::sam, output_format::sam_gzip) };
+  s.set_sample(sample);
+
+  s.header(buf, { "adapterremoval3", "--blah" });
+  REQUIRE(buf == "@HD\tVN:1.6\tSO:unsorted\n@RG\tID:foo.1\tSM:foo\t"
+                 "BC:ACGT-TGCA\n@RG\tID:foo.2\tSM:foo\tBC:TTGG-AGTT\n"
+                 "@PG\tID:adapterremoval\tPN:adapterremoval\t"
+                 "CL:adapterremoval3 --blah\tVN:3.0.0-alpha3\n"_buffer);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// SAM record serialization
+
+TEST_CASE("serialize SAM record without sample")
+{
+  buffer buf;
+  serializer s{ GENERATE(output_format::sam, output_format::sam_gzip) };
+  s.set_demultiplexing_only(GENERATE(true, false));
+
+  fastq record{ "record", "ACGTACGATA", "!$#$*68CGJ" };
+  s.record(buf, std::move(record), read_meta{ read_type::se });
+
+  REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
+                 "!$#$*68CGJ\n"_buffer);
+}
+
+TEST_CASE("serialize SAM record with sample")
+{
+  serializer s{ GENERATE(output_format::sam, output_format::sam_gzip) };
+  s.set_demultiplexing_only(GENERATE(true, false));
+  sample sample{ BASIC_SAMPLE_WITH_BARCODES };
+  sample.set_read_group(read_group{});
+  s.set_sample(sample);
+
+  buffer buf;
+  fastq record{ "record", "ACGTACGATA", "!$#$*68CGJ" };
+  s.record(buf, std::move(record), read_meta{ read_type::se });
+
+  REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t!$#$*68CGJ\t"
+                 "RG:Z:foo\n"_buffer);
+}
+
+TEST_CASE("serialize SAM record with mate separator")
+{
+  buffer buf;
+  serializer s{ GENERATE(output_format::sam, output_format::sam_gzip) };
+
+  fastq record{ "record/1", "ACGTACGATA", "!$#$*68CGJ" };
+
+  SECTION("without mate sep")
+  {
+    s.record(buf, std::move(record), read_meta{ read_type::se });
+    REQUIRE(buf == "record/1\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
+                   "!$#$*68CGJ\n"_buffer);
+  }
+
+  SECTION("with mate sep")
+  {
+    s.set_mate_separator('/');
+    s.record(buf, std::move(record), read_meta{ read_type::se });
+    REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
+                   "!$#$*68CGJ\n"_buffer);
+  }
+}
+
+TEST_CASE("serialize read types for SAM")
+{
+  buffer buf;
+  fastq record{ "record", "ACGTACGATA", "!$#$*68CGJ" };
+  serializer s{ GENERATE(output_format::sam, output_format::sam_gzip) };
+
+  SECTION("single end")
+  {
+    s.record(buf,
+             std::move(record),
+             read_meta{ GENERATE(read_type::se, read_type::merged) });
+    REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
+                   "!$#$*68CGJ\n"_buffer);
+  }
+
+  SECTION("single end failed QC")
+  {
+    s.record(buf,
+             std::move(record),
+             read_meta{ GENERATE(read_type::se_fail, read_type::merged_fail) });
+    REQUIRE(buf == "record\t516\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
+                   "!$#$*68CGJ\n"_buffer);
+  }
+
+  SECTION("paired end mate 1, mate 2 passed/failed")
+  {
+    s.record(buf,
+             std::move(record),
+             read_meta{ GENERATE(read_type::pe_1, read_type::singleton_1) });
+    REQUIRE(buf == "record\t77\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
+                   "!$#$*68CGJ\n"_buffer);
+  }
+
+  SECTION("paired end mate 1 failed, mate 2 passed/failed")
+  {
+    s.record(buf, std::move(record), read_meta{ read_type::pe_1_fail });
+    REQUIRE(buf == "record\t589\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
+                   "!$#$*68CGJ\n"_buffer);
+  }
+
+  SECTION("paired end mate 2, mate 1 passed/failed")
+  {
+    s.record(buf,
+             std::move(record),
+             read_meta{ GENERATE(read_type::pe_2, read_type::singleton_2) });
+    REQUIRE(buf == "record\t141\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
+                   "!$#$*68CGJ\n"_buffer);
+  }
+
+  SECTION("paired end mate 2 failed, mate 1 passed/failed")
+  {
+    s.record(buf, std::move(record), read_meta{ read_type::pe_2_fail });
+    REQUIRE(buf == "record\t653\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
+                   "!$#$*68CGJ\n"_buffer);
+  }
+}
+
+TEST_CASE("serialize empty SAM record")
+{
+  fastq record{ "record", "", "" };
+
+  buffer buf;
+  serializer s{ GENERATE(output_format::sam, output_format::sam_gzip) };
+  s.record(buf, std::move(record), read_meta{ read_type::se });
+
+  REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\t*\t*\n"_buffer);
+}
+
+TEST_CASE("serialize SAM record from FASTQ with meta-data")
+{
+  buffer buf;
+  serializer s{ GENERATE(output_format::sam, output_format::sam_gzip) };
+
+  fastq record{ "record length=NA", "ACGTACGATA", "!$#$*68CGJ" };
+  s.record(buf, std::move(record), read_meta{ read_type::se });
+
+  // The meta-data is (currently) not serialized
+  REQUIRE(buf == "record\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGATA\t"
+                 "!$#$*68CGJ\n"_buffer);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// BAM header serialization
+
+TEST_CASE("Writing BAM header to buffer", "[serializer::fastq]")
+{
+  serializer s{ GENERATE(output_format::bam, output_format::ubam) };
+
+  // Sample information is only written if there is a read group, either
+  // directly from the user or automatically assigned when demultiplexing
+  if (GENERATE(true, false)) {
+    sample sample{ BASIC_SAMPLE_WITH_BARCODES };
+    s.set_sample(sample);
+  }
+
+  buffer buf;
+  s.header(buf, { "adapterremoval3", "--blah" });
+  REQUIRE(buf == "BAM\x01i\x00\x00\x00@HD\tVN:1.6\tSO:unsorted\n"
+                 "@PG\tID:adapterremoval\tPN:adapterremoval\t"
+                 "CL:adapterremoval3 --blah\tVN:3.0.0-alpha3\n"
+                 "\x00\x00\x00\x00"_buffer);
+}
+
+TEST_CASE("Writing BAM read-group header to buffer", "[serializer::fastq]")
+{
+
+  sample sample{ BASIC_SAMPLE_WITH_BARCODES };
+  sample.set_read_group(read_group{ "LB:lib" });
+
+  serializer s{ GENERATE(output_format::bam, output_format::ubam) };
+  s.set_sample(sample);
+
+  buffer buf;
+  s.header(buf, { "adapterremoval3", "--blah" });
+  REQUIRE(buf == "BAM\x01\x8f\x00\x00\x00@HD\tVN:1.6\tSO:unsorted\n@RG\t"
+                 "ID:foo\tLB:lib\tSM:foo\tBC:ACGT-TGCA\n@PG\t"
+                 "ID:adapterremoval\tPN:adapterremoval\tCL:"
+                 "adapterremoval3 --blah\tVN:3.0.0-alpha3\n"
+                 "\x00\x00\x00\x00"_buffer);
+}
+
+TEST_CASE("Writing BAM read-group header to buffer with multiple barcodes",
+          "[serializer::fastq]")
+{
+  sample sample{ BASIC_SAMPLE_WITH_BARCODES };
+  sample.add(dna_sequence{ "TTGG" },
+             dna_sequence{ "AGTT" },
+             barcode_orientation::unspecified);
+  sample.set_read_group({});
+
+  serializer s{ GENERATE(output_format::bam, output_format::ubam) };
+  s.set_sample(sample);
+
+  buffer buf;
+  s.header(buf, { "adapterremoval3", "--blah" });
+  REQUIRE(buf == "BAM\x01\xab\x00\x00\x00@HD\tVN:1.6\tSO:unsorted\n@RG\t"
+                 "ID:foo.1\tSM:foo\tBC:ACGT-TGCA\n@RG\tID:foo.2\t"
+                 "SM:foo\tBC:TTGG-AGTT\n@PG\tID:adapterremoval\t"
+                 "PN:adapterremoval\tCL:adapterremoval3 "
+                 "--blah\tVN:3.0.0-alpha3\n\x00\x00\x00\x00"_buffer);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BAM record serialization
+
+TEST_CASE("serialize BAM record without sample")
+{
+  buffer buf;
+  serializer s{ GENERATE(output_format::bam, output_format::ubam) };
+  s.set_demultiplexing_only(GENERATE(true, false));
+
+  fastq record{ "record", "ACGTACGATA", "!$#$*68CGJ" };
+  s.record(buf, std::move(record), read_meta{ read_type::se });
+
+  REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
+                 "\x00\x00\x04\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
+                 "\xff\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02"
+                 "\x03\t\x15\x17\"&)"_buffer);
+}
+
+TEST_CASE("serialize BAM record with uneven length sequence")
+{
+  buffer buf;
+  serializer s{ GENERATE(output_format::bam, output_format::ubam) };
+  s.set_demultiplexing_only(GENERATE(true, false));
+
+  fastq record{ "record", "ACGTACGAT", "!$#$*68CG" };
+  s.record(buf, std::move(record), read_meta{ read_type::se });
+
+  REQUIRE(buf == "5\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
+                 "\x00\x00\x04\x00\t\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
+                 "\xff\x00\x00\x00\x00record\x00\x12H\x12\x41\x80\x00\x03\x02"
+                 "\x03\t\x15\x17\"&"_buffer);
+}
+
+TEST_CASE("serialize BAM record with sample")
+{
+  serializer s{ GENERATE(output_format::bam, output_format::ubam) };
+  s.set_demultiplexing_only(GENERATE(true, false));
+  sample sample{ BASIC_SAMPLE_WITH_BARCODES };
+  sample.set_read_group(read_group{});
+  s.set_sample(sample);
+
+  buffer buf;
+  fastq record{ "record", "ACGTACGATA", "!$#$*68CGJ" };
+  s.record(buf, std::move(record), read_meta{ read_type::se });
+
+  REQUIRE(buf == "=\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
+                 "\x00\x00\x04\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
+                 "\xff\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02"
+                 "\x03\t\x15\x17\"&)RGZfoo\x00"_buffer);
+}
+
+TEST_CASE("serialize BAM record with mate separator")
+{
+  buffer buf;
+  serializer s{ GENERATE(output_format::bam, output_format::ubam) };
+
+  fastq record{ "record/1", "ACGTACGATA", "!$#$*68CGJ" };
+
+  SECTION("without mate sep")
+  {
+    s.record(buf, std::move(record), read_meta{ read_type::se });
+    REQUIRE(buf == "8\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\t\x00H\x12"
+                   "\x00\x00\x04\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
+                   "\xff\x00\x00\x00\x00record/1\x00\x12H\x12\x41\x81\x00\x03"
+                   "\x02\x03\t\x15\x17\"&)"_buffer);
+  }
+
+  SECTION("with mate sep")
+  {
+    s.set_mate_separator('/');
+    s.record(buf, std::move(record), read_meta{ read_type::se });
+    REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
+                   "\x00\x00\x04\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
+                   "\xff\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02"
+                   "\x03\t\x15\x17\"&)"_buffer);
+  }
+}
+
+TEST_CASE("serialize read types for BAM")
+{
+  buffer buf;
+  fastq record{ "record", "ACGTACGATA", "!$#$*68CGJ" };
+  serializer s{ GENERATE(output_format::bam, output_format::ubam) };
+
+  SECTION("single end")
+  {
+    s.record(buf,
+             std::move(record),
+             read_meta{ GENERATE(read_type::se, read_type::merged) });
+    REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
+                   "\x00\x00\x04\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
+                   "\xff\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02"
+                   "\x03\t\x15\x17\"&)"_buffer);
+  }
+
+  SECTION("single end failed QC")
+  {
+    s.record(buf,
+             std::move(record),
+             read_meta{ GENERATE(read_type::se_fail, read_type::merged_fail) });
+    REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
+                   "\x00\x00\x04\x02\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
+                   "\xff\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02"
+                   "\x03\t\x15\x17\"&)"_buffer);
+  }
+
+  SECTION("paired end mate 1, mate 2 passed/failed")
+  {
+    s.record(buf,
+             std::move(record),
+             read_meta{ GENERATE(read_type::pe_1, read_type::singleton_1) });
+    REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
+                   "\x00\x00M\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff"
+                   "\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02\x03"
+                   "\t\x15\x17\"&)"_buffer);
+  }
+
+  SECTION("paired end mate 1 failed, mate 2 passed/failed")
+  {
+    s.record(buf, std::move(record), read_meta{ read_type::pe_1_fail });
+    REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
+                   "\x00\x00M\x02\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff"
+                   "\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02\x03"
+                   "\t\x15\x17\"&)"_buffer);
+  }
+
+  SECTION("paired end mate 2, mate 1 passed/failed")
+  {
+    s.record(buf,
+             std::move(record),
+             read_meta{ GENERATE(read_type::pe_2, read_type::singleton_2) });
+    REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
+                   "\x00\x00\x8d\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
+                   "\xff\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02"
+                   "\x03\t\x15\x17\"&)"_buffer);
+  }
+
+  SECTION("paired end mate 2 failed, mate 1 passed/failed")
+  {
+    s.record(buf, std::move(record), read_meta{ read_type::pe_2_fail });
+    REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
+                   "\x00\x00\x8d\x02\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
+                   "\xff\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02"
+                   "\x03\t\x15\x17\"&)"_buffer);
+  }
+}
+
+TEST_CASE("serialize empty BAM record")
+{
+  fastq record{ "record", "", "" };
+
+  buffer buf;
+  serializer s{ GENERATE(output_format::bam, output_format::ubam) };
+  s.record(buf, std::move(record), read_meta{ read_type::se });
+
+  REQUIRE(buf == "'\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
+                 "\x00\x00\x04\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
+                 "\xff\x00\x00\x00\x00record\x00"_buffer);
+}
+
+TEST_CASE("serialize BAM record from FASTQ with meta-data")
+{
+  buffer buf;
+  serializer s{ GENERATE(output_format::bam, output_format::ubam) };
+
+  fastq record{ "record length=NA", "ACGTACGATA", "!$#$*68CGJ" };
+  s.record(buf, std::move(record), read_meta{ read_type::se });
+
+  // The meta-data is (currently) not serialized
+  REQUIRE(buf == "6\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x07\x00H\x12"
+                 "\x00\x00\x04\x00\n\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff"
+                 "\xff\x00\x00\x00\x00record\x00\x12H\x12\x41\x81\x00\x03\x02"
+                 "\x03\t\x15\x17\"&)"_buffer);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Common SAM/BAM tests
+
+TEST_CASE("Serializing too long read names")
+{
+  // The maximum allowed read name length for SAM/BAM
+  static_assert(EXTREMELY_LONG_NAME.size() == 254);
+
+  auto name = std ::string{ EXTREMELY_LONG_NAME };
+  fastq record_254{ name, "ACGT", "!!!!" };
+  fastq record_255{ name + "5", "ACGT", "!!!!" };
+
+  const read_meta meta{ read_type::se };
+  buffer buf;
+
+  SECTION("fastq is always valid")
+  {
+    serializer s{ GENERATE(output_format::fastq, output_format::fastq_gzip) };
+    CHECK_NOTHROW(s.record(buf, std::move(record_254), meta));
+    CHECK_NOTHROW(s.record(buf, std::move(record_255), meta));
+  }
+
+  SECTION("SAM/BAM allows only 254 characters")
+  {
+    serializer s{ GENERATE(output_format::sam,
+                           output_format::sam_gzip,
+                           output_format::bam,
+                           output_format::ubam) };
+
+    CHECK_NOTHROW(s.record(buf, std::move(record_254), meta));
+    REQUIRE_THROWS_WITH(s.record(buf, std::move(record_255), meta),
+                        Catch::Contains("Cannot encode read as SAM/BAM; read "
+                                        "name is longer than 254 characters"));
+  }
+}
+
+TEST_CASE("invalid read names")
+{
+  const read_meta meta{ read_type::se };
+  fastq record{ "invalid\tname", "ACGT", "!!!!" };
+  buffer buf;
+
+  SECTION("FASTQ allows anything")
+  {
+    serializer s{ GENERATE(output_format::fastq, output_format::fastq_gzip) };
+    CHECK_NOTHROW(s.record(buf, std::move(record), meta));
+  }
+
+  SECTION("SAM/BAM limits valid characters")
+  {
+    serializer s{ GENERATE(output_format::sam,
+                           output_format::sam_gzip,
+                           output_format::bam,
+                           output_format::ubam) };
+
+    REQUIRE_THROWS_WITH(s.record(buf, std::move(record), meta),
+                        Catch::Contains("Cannot encode read as SAM/BAM; read "
+                                        "name contains characters other than "
+                                        "the allowed"));
+  }
 }
 
 } // namespace adapterremoval


### PR DESCRIPTION
The read_type enum is further more expanded, allowing the file_type to be derived from the read_type enum.

Unit tests are added for serializing FASTQ, SAM, and BAM, for each read type