### PR TITLE
avoid undefined behavior when stringifying enums

### DIFF
--- a/src/sequence_sets.cpp
+++ b/src/sequence_sets.cpp
@@ -735,7 +735,7 @@ operator<<(std::ostream& os, const barcode_orientation& value)
     case barcode_orientation::reverse:
       return os << "barcode_orientation::reverse";
     default:
-      return os << "barcode_orientation{" << underlying_value(value) << "}";
+      return os << "barcode_orientation{?}";
   }
 }
 
@@ -752,8 +752,7 @@ operator<<(std::ostream& os, const barcode_table_orientation& value)
     case barcode_table_orientation::explicit_:
       return os << "barcode_table_orientation::explicit_";
     default:
-      return os << "barcode_table_orientation{" << underlying_value(value)
-                << "}";
+      return os << "barcode_table_orientation{?}";
   }
 }
 

--- a/tests/unit/sequence_sets/common_test.cpp
+++ b/tests/unit/sequence_sets/common_test.cpp
@@ -56,8 +56,6 @@ TEST_CASE("barcode_orientation to debug string", "[barcode_orientation]")
         "barcode_orientation::forward");
   CHECK(fallbackStringifier(barcode_orientation::reverse) ==
         "barcode_orientation::reverse");
-  CHECK(fallbackStringifier(static_cast<barcode_orientation>(-3)) ==
-        "barcode_orientation{-3}");
 }
 
 TEST_CASE("barcode_table_orientation to debug string", "[barcode_orientation]")
@@ -72,8 +70,6 @@ TEST_CASE("barcode_table_orientation to debug string", "[barcode_orientation]")
         "barcode_table_orientation::reverse");
   CHECK(fallbackStringifier(barcode_table_orientation::explicit_) ==
         "barcode_table_orientation::explicit_");
-  CHECK(fallbackStringifier(static_cast<barcode_table_orientation>(-3)) ==
-        "barcode_table_orientation{-3}");
 }
 
 } // namespace adapterremoval

--- a/tests/unit/serializer_test.cpp
+++ b/tests/unit/serializer_test.cpp
@@ -58,7 +58,7 @@ operator<<(std::ostream& os, const read_file& value)
       return os << "read_file::discarded";
     case read_file::max:
     default:
-      return os << "read_file{" << underlying_value(value) << "}";
+      return os << "read_file{?}";
   }
 }
 


### PR DESCRIPTION
It is not completely clear to me what is allowed, based on the spec, so playing it safe