### PR TITLE
fix misleading io error messages

### DIFF
--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -56,8 +56,7 @@ format_io_error(const std::string& message, const int error_number)
 {
   if (error_number) {
     std::ostringstream stream;
-    stream << message << " ('" << strerror_r_wrapper(::strerror_r, error_number)
-           << "')";
+    stream << message << ": " << strerror_r_wrapper(::strerror_r, error_number);
 
     return stream.str();
   } else {
@@ -70,10 +69,13 @@ assert_failed::assert_failed(const std::string& what)
 {
 }
 
+io_error::io_error(const std::string& message)
+  : std::runtime_error(message)
+{
+}
+
 io_error::io_error(const std::string& message, int error_number)
-  : std::ios_base::failure(
-      message,
-      std::error_code(error_number, std::generic_category()))
+  : std::runtime_error(format_io_error(message, error_number))
 {
 }
 

--- a/src/errors.hpp
+++ b/src/errors.hpp
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2024 Mikkel Schubert <mikkelsch@gmail.com>
 #pragma once
 
-#include <ios>       // for ios_base::failure
 #include <iosfwd>    // for ostream
 #include <stdexcept> // for runtime_error
 #include <string>    // for string
@@ -21,11 +20,14 @@ public:
 };
 
 /** Represents errors during basic IO. */
-class io_error : public std::ios_base::failure
+class io_error : public std::runtime_error
 {
 public:
+  /** Produces an error without an associated error code */
+  explicit io_error(const std::string& message);
+
   /** Produces a combined error including a description of the error code */
-  explicit io_error(const std::string& message, int error_number = 0);
+  explicit io_error(const std::string& message, int error_number);
 };
 
 /** Represents errors during GZip (de)compression. */

--- a/src/fastq_io.cpp
+++ b/src/fastq_io.cpp
@@ -633,7 +633,7 @@ write_fastq::process(chunk_ptr chunk)
 
       m_output.write(trailer, flush::on);
     }
-  } catch (const std::ios_base::failure&) {
+  } catch (const io_error&) {
     std::ostringstream msg;
     msg << "Error writing to FASTQ file " << shell_escape(m_output.filename());
 
@@ -652,7 +652,7 @@ write_fastq::finalize()
   // Close file to trigger any exceptions due to badbit / failbit
   try {
     m_output.close();
-  } catch (const std::ios_base::failure&) {
+  } catch (const io_error&) {
     std::ostringstream msg;
     msg << "Error closing FASTQ file " << shell_escape(m_output.filename());
 

--- a/src/reports_html.cpp
+++ b/src/reports_html.cpp
@@ -3,6 +3,7 @@
 #include "adapter_id.hpp"            // for adapter_id_statistics
 #include "counts.hpp"                // for counts, indexed_count, counts_tmpl
 #include "debug.hpp"                 // for AR_REQUIRE
+#include "errors.hpp"                // for io_error
 #include "fastq.hpp"                 // for ACGT, ACGT::values, fastq, ACGTN
 #include "json.hpp"                  // for json_dict, json_list, json_ptr
 #include "logging.hpp"               // for log_stream, error
@@ -1269,7 +1270,7 @@ write_html_report(const userconfig& config,
     managed_writer writer{ filename };
     writer.write(output.str());
     writer.close();
-  } catch (const std::ios_base::failure& error) {
+  } catch (const io_error& error) {
     log::error() << "Error writing JSON report to '" << filename << "':\n"
                  << indent_lines(error.what());
     return false;

--- a/src/reports_json.cpp
+++ b/src/reports_json.cpp
@@ -5,6 +5,7 @@
 #include "commontypes.hpp"   // for read_file, read_file::mate_1, read_typ...
 #include "counts.hpp"        // for counts, counts_tmpl, indexed_count
 #include "debug.hpp"         // for AR_REQUIRE
+#include "errors.hpp"        // for io_error
 #include "fastq.hpp"         // for ACGT, fastq, ACGT::values
 #include "json.hpp"          // for json_dict, json_dict_ptr, json_list
 #include "logging.hpp"       // for log_stream, error
@@ -703,7 +704,7 @@ write_json_report(const userconfig& config,
     managed_writer writer{ filename };
     writer.write(output.str());
     writer.close();
-  } catch (const std::ios_base::failure& error) {
+  } catch (const io_error& error) {
     log::error() << "Error writing JSON report to '" << filename << "':\n"
                  << indent_lines(error.what());
     return false;


### PR DESCRIPTION
In particular, errors without assosiated error codes would include nonsensical error descriptions. The use of ios_base::failure is dropped, since IO generally is not done using iostreams