### PR TITLE
enable hardening by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DEBUG := ${COVERAGE}
 SANITIZE := false
 
 # Enable hardening flags
-HARDEN := false
+HARDEN := true
 
 # Generate statically linked binary
 # It is recommended to use the included Containerfile to build the static binary

--- a/meson.build
+++ b/meson.build
@@ -84,10 +84,13 @@ harden = get_option('harden')
 if harden
     add_project_arguments(
         compiler.get_supported_arguments(
-            '-D_FORTIFY_SOURCE=2',
+            '-D_FORTIFY_SOURCE=3',
+            '-D_GLIBCXX_ASSERTIONS',
             '-fPIE',
-            '-fstack-protector-all',
+            '-fcf-protection=full',
             '-fstack-clash-protection',
+            '-fstack-protector-strong',
+            '-ftrivial-auto-var-init=zero',
         ),
         language: 'cpp',
     )

--- a/meson.build
+++ b/meson.build
@@ -84,6 +84,8 @@ harden = get_option('harden')
 if harden
     add_project_arguments(
         compiler.get_supported_arguments(
+            # Workaround for systems where _FORTIFY_SOURCE is defined by default
+            '-U_FORTIFY_SOURCE',
             '-D_FORTIFY_SOURCE=3',
             '-D_GLIBCXX_ASSERTIONS',
             '-fPIE',

--- a/meson.options
+++ b/meson.options
@@ -16,6 +16,6 @@ option(
 option(
     'harden',
     type: 'boolean',
-    value: false,
+    value: true,
     description: 'Build executable with hardening flags',
 )


### PR DESCRIPTION
This comes at a small performance cost, but it is expected that many distros will be enabling similar flags as well.

Flags updated (mostly) based on -fhardening