### PR TITLE
fix edge case in SE alignments

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -36,7 +36,7 @@ sequence_aligner::pairwise_align_sequences(alignment_info& alignment,
   // the maximum possible score is `length` when all bases match
   int end_offset =
     std::min(max_offset,
-             static_cast<int>(seq1_len) - std::max(1, alignment.score()));
+             static_cast<int>(seq1_len) - std::max(0, alignment.score()) - 1);
 
   bool alignment_found = false;
   for (; offset <= end_offset; ++offset) {

--- a/tests/unit/alignment_test.cpp
+++ b/tests/unit/alignment_test.cpp
@@ -720,6 +720,21 @@ TEST_CASE("Adapter only sequences, with missing base",
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// Misc
+
+// Test for bug where SE alignments would occasionally test sequences with fewer
+// bp than the current score, that therefore could never be picked.
+TEST_CASE("Pointless SE alignments", "[alignment::single_end]")
+{
+  // Subsequent candidates can never be better than the best previous alignment
+  const adapter_set adapters{ { "TT", "" }, { "T", "" }, {} };
+  sequence_aligner aligner{ adapters, simd::instruction_set::none };
+  const alignment_info expected = ALN().length(2).adapter_id(0);
+  const auto result = aligner.align_single_end({ "Rec", "TTT" }, 0);
+  REQUIRE(result == expected);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 //
 
 TEST_CASE("Invalid alignment", "[alignment::paired_end]")


### PR DESCRIPTION
This commit fixes an edge case involving multiple adapters, in which alignments involving too few bp to matter would occasionally be tried, which would trigger an assert