### PR TITLE
make threadstate::release argument by value

### DIFF
--- a/src/demultiplexing.cpp
+++ b/src/demultiplexing.cpp
@@ -201,7 +201,7 @@ process_demultiplexed::process(chunk_ptr chunk)
     }
   }
 
-  m_stats.release(stats);
+  m_stats.release(std::move(stats));
 
   return chunks.finalize(chunk->eof);
 }
@@ -276,8 +276,8 @@ processes_unidentified::process(chunk_ptr chunk)
     }
   }
 
-  m_stats_1.release(stats_1);
-  m_stats_2.release(stats_2);
+  m_stats_1.release(std::move(stats_1));
+  m_stats_2.release(std::move(stats_2));
 
   return chunks.finalize(chunk->eof);
 }

--- a/src/fastq_io.cpp
+++ b/src/fastq_io.cpp
@@ -341,7 +341,7 @@ post_process_fastq::process(chunk_ptr chunk)
     }
   }
 
-  m_stats.release(stats);
+  m_stats.release(std::move(stats));
 
   {
     std::unique_lock<std::mutex> lock(m_timer_lock);

--- a/src/main_adapter_id.cpp
+++ b/src/main_adapter_id.cpp
@@ -94,8 +94,8 @@ public:
       }
     }
 
-    m_stats_id.release(stats_id);
-    m_stats_ins.release(stats_ins);
+    m_stats_id.release(std::move(stats_id));
+    m_stats_ins.release(std::move(stats_ins));
 
     return {};
   }

--- a/src/scheduler.hpp
+++ b/src/scheduler.hpp
@@ -31,7 +31,8 @@ class threadstate
 public:
   threadstate() = default;
 
-  using pointer = std::unique_ptr<T>;
+  using value_type = T;
+  using pointer = std::unique_ptr<value_type>;
 
   /** Create a new state value **/
   template<class... Args>
@@ -76,7 +77,7 @@ public:
   }
 
   /** Release ownership of a value. **/
-  void release(pointer& value)
+  void release(pointer value)
   {
     AR_REQUIRE(value);
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/trimming.cpp
+++ b/src/trimming.cpp
@@ -383,7 +383,7 @@ se_reads_processor::process(chunk_ptr chunk)
     }
   }
 
-  m_stats.release(stats);
+  m_stats.release(std::move(stats));
 
   return chunks.finalize(chunk->eof);
 }
@@ -619,7 +619,7 @@ pe_reads_processor::process(chunk_ptr chunk)
   stats->reads_merged.inc_reads(merger.reads_merged());
   stats->reads_merged.inc_bases(merger.bases_merged());
 
-  m_stats.release(stats);
+  m_stats.release(std::move(stats));
 
   return chunks.finalize(chunk->eof);
 }

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -18,6 +18,7 @@ unit_tests = executable(
     'main_test.cpp',
     'mathutils_test.cpp',
     'read_group_test.cpp',
+    'scheduler_test.cpp',
     'sequence_sets' / 'adapter_set_test.cpp',
     'sequence_sets' / 'common_test.cpp',
     'sequence_sets' / 'sample_set_test.cpp',

--- a/tests/unit/scheduler_test.cpp
+++ b/tests/unit/scheduler_test.cpp
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2022 Mikkel Schubert <mikkelsch@gmail.com>
+#include "errors.hpp"    // for assertion_failed
+#include "scheduler.hpp" // for threadstate
+#include "testing.hpp"   // for TEST_CASE, REQUIRE, ...
+#include <memory>        // for unique_ptr
+
+namespace Catch {
+
+template<>
+std::string
+fallbackStringifier(const std::unique_ptr<int>& value)
+{
+  ReusableStringStream ss;
+
+  if (value) {
+    ss << "unique_ptr({" << *value << "})";
+  } else {
+    ss << "unique_ptr(null)";
+  }
+
+  return ss.str();
+}
+
+} // namespace Catch
+
+namespace adapterremoval {
+
+TEST_CASE("empty threadstate", "[scheduler::threadstate]")
+{
+  threadstate<int> state;
+
+  REQUIRE_THROWS_AS(state.acquire(), assert_failed);
+  REQUIRE(state.try_acquire() == threadstate<int>::pointer());
+}
+
+TEST_CASE("threadstate emplace back", "[scheduler::threadstate]")
+{
+  threadstate<int> state;
+  state.emplace_back(1234);
+
+  SECTION("acquire")
+  {
+    auto value = state.acquire();
+    REQUIRE(value);
+    REQUIRE(*value == 1234);
+    REQUIRE_THROWS_AS(state.acquire(), assert_failed);
+  }
+
+  SECTION("try acquire")
+  {
+    auto value = state.try_acquire();
+    REQUIRE(value);
+    REQUIRE(*value == 1234);
+    REQUIRE(state.try_acquire() == threadstate<int>::pointer());
+  }
+}
+
+TEST_CASE("threadstate emplace back n", "[scheduler::threadstate]")
+{
+  threadstate<int> state;
+  state.emplace_back_n(3, 1234);
+
+  for (size_t i = 0; i < 3; ++i) {
+    auto value = state.acquire();
+    REQUIRE(value);
+    REQUIRE(*value == 1234);
+  }
+
+  REQUIRE_THROWS_AS(state.acquire(), assert_failed);
+}
+
+TEST_CASE("threadstate release", "[scheduler::threadstate]")
+{
+  threadstate<int> state;
+  state.emplace_back(1234);
+
+  auto value = state.acquire();
+  REQUIRE(value);
+  REQUIRE(*value == 1234);
+  REQUIRE_THROWS_AS(state.acquire(), assert_failed);
+
+  state.release(std::move(value));
+
+  value = state.acquire();
+  REQUIRE(value);
+  REQUIRE(*value == 1234);
+  REQUIRE_THROWS_AS(state.acquire(), assert_failed);
+}
+
+TEST_CASE("threadstate release lvalue", "[scheduler::threadstate]")
+{
+  threadstate<int> state;
+  state.release(std::make_unique<int>(1234));
+
+  auto value = state.acquire();
+  REQUIRE(value);
+  REQUIRE(*value == 1234);
+  REQUIRE_THROWS_AS(state.acquire(), assert_failed);
+}
+
+TEST_CASE("threadstate merg into", "[scheduler::threadstate]")
+{
+  threadstate<int> state;
+  state.emplace_back(1);
+  state.emplace_back(3);
+  state.emplace_back(5);
+
+  int destination = 10;
+  state.merge_into(destination);
+  REQUIRE(destination == 19);
+  REQUIRE_THROWS_AS(state.acquire(), assert_failed);
+}
+
+} // namespace adapterremoval


### PR DESCRIPTION
This makes releasing more explicit, and allows lvalues to be released