### PR TITLE
20% higher throughput for PE trimming using NEON

### DIFF
--- a/src/simd_neon.cpp
+++ b/src/simd_neon.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2022 Mikkel Schubert <mikkelsch@gmail.com>
 #include "simd.hpp"   // declarations
-#include <algorithm>  //
+#include <algorithm>  // for min
 #include <arm_neon.h> // for vdupq_n_u8, vld1q_u8, vorrq_u8, ...
 #include <cstddef>    // for size_t
 


### PR DESCRIPTION
Process blocks in batches using NEON SIMD instructions.

This yields a roughly 2x increase in alignment speed for PE alignments and a small (up to 5%) decrease in alignment speed for shorter SE alignments (tested on 1M reads/read pairs):

```
     Benchmark |       Min |      Mean |       Max | SD (%) | Loops | Outliers
PE  90 bp, new |   705,471 |   706,840 |   709,209 |   0.19 |    10 |        0
PE  90 bp, old | 1,353,461 | 1,355,887 | 1,358,186 |   0.14 |    10 |        0

PE 151 bp, new | 1,274,855 | 1,275,260 | 1,276,002 |   0.04 |    10 |        0
PE 151 bp, old | 2,699,288 | 2,703,584 | 2,709,823 |   0.16 |    10 |        0

PE 251 bp, new | 3,044,884 | 3,062,679 | 3,078,010 |   0.37 |    10 |        0
PE 251 bp, old | 6,193,364 | 6,201,703 | 6,226,089 |   0.18 |    10 |        2

SE  90 bp, new |   315,076 |   316,141 |   319,009 |   0.39 |    16 |        1
SE  90 bp, old |   317,847 |   318,442 |   319,223 |   0.14 |    16 |        2

SE 151 bp, new |   493,804 |   495,057 |   497,465 |   0.24 |    11 |        1
SE 151 bp, old |   483,017 |   483,302 |   483,591 |   0.04 |    11 |        0

SE 251 bp, new |   792,004 |   793,074 |   794,197 |   0.10 |    10 |        1
SE 251 bp, old |   756,888 |   758,570 |   760,779 |   0.21 |    10 |        1
```

In real terms, this yields a ~20% increase in end-to-end throughput with merging and compressed output for PE reads, and no measurable change for SE reads:

```
K reads/second, for 1M reads/read pairs:

            old   new
PE  90 bp   614   705
PE 151 bp   443   529
PE 251 bp   221   268

SE  90 bp   680   680
SE 151 bp   529   529
SE 251 bp   289   289
```