### PR TITLE
rename master to main

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -3,7 +3,7 @@ name: build
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       # Should maybe be added, but causes some amount of churn
       # - id: end-of-file-fixer
       - id: no-commit-to-branch
-        args: [--branch, master, --branch, 2.3.x]
+        args: [--branch, main, --branch, 2.3.x]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: a8c7c3ac16eabd3b958952ea0d6bf1dceeab6411 # v19.1.2
     hooks:

--- a/README-v3.md
+++ b/README-v3.md
@@ -35,7 +35,7 @@ AdapterRemoval v3 features greatly increased throughput compared to AdapterRemov
 
 Please note that these results are preliminary:
 
-![Throughput for ARv2, ARv3, and fastp](https://raw.githubusercontent.com/MikkelSchubert/adapterremoval/master/docs/images/throughput.svg)
+![Throughput for ARv2, ARv3, and fastp](https://raw.githubusercontent.com/MikkelSchubert/adapterremoval/main/docs/images/throughput.svg)
 
 Point labels indicate the number of worker threads configured for each program, while the X-axis indicates observed CPU-usage for a given number of worker threads. The Y-axis indicates millions of 150bp paired-end reads processed per second, for gzipped input and output, with merging enabled and duplication estimation disabled.
 


### PR DESCRIPTION
Rename `master` branch to `main` for my own convenience