### PR TITLE
--merge-strategy should not imply --merge

### DIFF
--- a/src/userconfig.cpp
+++ b/src/userconfig.cpp
@@ -955,7 +955,7 @@ userconfig::userconfig()
       "The 'maximum' strategy uses Q=max(Q1,Q2) for matches while the "
       "'additive' strategy uses Q=Q1+Q2. Both strategies use Q=abs(Q1-Q2) for "
       "mismatches and picks the highest quality base, unless the qualities are "
-      "the same in which case 'N' is used. Setting this option implies --merge")
+      "the same in which case 'N' is used")
     .bind_str(nullptr)
     .with_choices({ "maximum", "additive" })
     .with_default("maximum");

--- a/src/userconfig.cpp
+++ b/src/userconfig.cpp
@@ -1434,8 +1434,7 @@ userconfig::parse_args(const string_vec& argvec)
       merge = merge_strategy::additive;
     } else if (argparser.is_set("--collapse-conservatively")) {
       merge = merge_strategy::maximum;
-    } else if (argparser.is_set("--merge") ||
-               argparser.is_set("--merge-strategy")) {
+    } else if (argparser.is_set("--merge")) {
       const auto strategy = argparser.value("--merge-strategy");
       if (strategy == "maximum") {
         merge = merge_strategy::maximum;


### PR DESCRIPTION
While this behavior matches the old --collapse-* options, it does not match any non-depreacted options