### PR TITLE
fix compatibility with meson >= 0.56.0

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -28,7 +28,8 @@ if sphinx_build.found()
             '-q', # no output on stdout, just warnings on stderr
             '-E', # don't use a saved environment, always read all files
         ],
-        install: get_option('docs').allowed(),
+        # Meson >=0.59.0 required for `allowed()`
+        install: not get_option('docs').disabled(),
         install_dir: get_option('datadir') / meson.project_name() / 'docs',
     )
 
@@ -51,7 +52,7 @@ if sphinx_build.found()
                     '@PRIVATE_DIR@' / 'man' / (meson.project_name() + '.1'),
                 ),
             ],
-            install: get_option('manpage').allowed(),
+            install: not get_option('manpage').disabled(),
             install_dir: join_paths(get_option('mandir'), 'man1'),
         )
     endif

--- a/meson.build
+++ b/meson.build
@@ -100,7 +100,21 @@ if static
 endif
 
 # Build static binary, forcing linking against static libraries
-libmimalloc = dependency('libmimalloc', 'mimalloc', version: ['>=2', '<4'], static: static, required: get_option('mimalloc'))
+libmimalloc = not_found
+# Meson >=0.59.0 required for `allowed()`
+if not get_option('mimalloc').disabled()
+    libmimalloc = dependency('libmimalloc', version: ['>=2', '<4'], static: static, required: false)
+
+    # Meson >=0.60.0 required for multiple names in a dependency
+    if not libmimalloc.found()
+        libmimalloc = dependency(
+            'mimalloc',
+            version: ['>=2', '<4'],
+            static: static,
+            required: get_option('mimalloc'),
+        )
+    endif
+endif
 
 # Hardening flags based on https://wiki.debian.org/Hardening
 harden = get_option('harden')

--- a/src/simd.hpp
+++ b/src/simd.hpp
@@ -44,7 +44,7 @@ using compare_subsequences_func = bool (*)(size_t& n_mismatches,
                                  const char* seq_1,                            \
                                  const char* seq_2,                            \
                                  size_t length,                                \
-                                 size_t max_penalty);
+                                 size_t max_penalty)
 
 DECLARE_COMPARE_SUBSEQUENCES_SIMD(std);
 DECLARE_COMPARE_SUBSEQUENCES_SIMD(sse2);


### PR DESCRIPTION
This is a partial revert of 539a7956cf70d92a6bc595b76e9dc4e9abd3f5e4