### PR TITLE
run unit-tests in random order

### DIFF
--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -45,5 +45,6 @@ run_target(
     command: [
         unit_tests,
         '--use-colour', 'yes',
+        '--order', 'rand',
     ],
 )


### PR DESCRIPTION
this is done to avoid tests depending on ordering and masking bugs, such as g_log_timestamps in 2b55ab0458b329f69af09a28fbf3b7f7c123e020