### PR TITLE
tweak msys2 packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,17 +79,16 @@ jobs:
         with:
           msystem: ucrt64
           install: |
-            git
-            make
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-git
             mingw-w64-ucrt-x86_64-isa-l
+            mingw-w64-ucrt-x86_64-make
             mingw-w64-ucrt-x86_64-meson
             mingw-w64-ucrt-x86_64-mimalloc
             mingw-w64-ucrt-x86_64-python
-            mingw-w64-ucrt-x86_64-python-jsonschema
+            mingw-w64-ucrt-x86_64-python-fastjsonschema
             mingw-w64-ucrt-x86_64-python-sphinx
-            mingw-w64-ucrt-x86_64-uv
 
       - if: ${{ matrix.os != 'windows-latest' }}
         name: dependencies (Unix)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,11 +79,11 @@ jobs:
         with:
           msystem: ucrt64
           install: |
+            make
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-git
             mingw-w64-ucrt-x86_64-isa-l
-            mingw-w64-ucrt-x86_64-make
             mingw-w64-ucrt-x86_64-meson
             mingw-w64-ucrt-x86_64-mimalloc
             mingw-w64-ucrt-x86_64-python

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,18 +75,17 @@ jobs:
         with:
           msystem: ucrt64
           install: |
-            git
-            make
             mingw-w64-ucrt-x86_64-ccache
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-git
             mingw-w64-ucrt-x86_64-isa-l
+            mingw-w64-ucrt-x86_64-make
             mingw-w64-ucrt-x86_64-meson
             mingw-w64-ucrt-x86_64-mimalloc
             mingw-w64-ucrt-x86_64-python
-            mingw-w64-ucrt-x86_64-python-jsonschema
+            mingw-w64-ucrt-x86_64-python-fastjsonschema
             mingw-w64-ucrt-x86_64-python-sphinx
-            mingw-w64-ucrt-x86_64-uv
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,12 +75,12 @@ jobs:
         with:
           msystem: ucrt64
           install: |
+            make
             mingw-w64-ucrt-x86_64-ccache
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-git
             mingw-w64-ucrt-x86_64-isa-l
-            mingw-w64-ucrt-x86_64-make
             mingw-w64-ucrt-x86_64-meson
             mingw-w64-ucrt-x86_64-mimalloc
             mingw-w64-ucrt-x86_64-python

--- a/scripts/build-common.sh
+++ b/scripts/build-common.sh
@@ -13,7 +13,7 @@ fi
 echo RUNNING COMPILE
 make executables
 
-echo "Built '$(./build/src/adapterremoval3 --version)'"
+echo "Built '$(./build/src/adapterremoval3 --version 2>&1)'"
 
 echo RUNNING TESTS
 make tests

--- a/scripts/build-common.sh
+++ b/scripts/build-common.sh
@@ -13,6 +13,8 @@ fi
 echo RUNNING COMPILE
 make executables
 
+echo "Built '$(./build/src/adapterremoval3 --version)'"
+
 echo RUNNING TESTS
 make tests
 

--- a/scripts/setup-ubuntu-latest.sh
+++ b/scripts/setup-ubuntu-latest.sh
@@ -9,5 +9,5 @@ sudo apt-get install -y \
 	ninja-build \
 	pkgconf \
 	python3 \
-	python3-jsonschema \
+	python3-fastjsonschema \
 	python3-sphinx


### PR DESCRIPTION
- Correct `jsonschema` to `fastjsonschema`
- `uv` is no longer needed
- Always use `ucrt` packages