### PR TITLE
round rather than truncate in phred calculation

### DIFF
--- a/src/fastq_enc.cpp
+++ b/src/fastq_enc.cpp
@@ -448,11 +448,13 @@ fastq_encoding::p_to_phred(double p)
 char
 fastq_encoding::p_to_phred_33(double p)
 {
-  AR_REQUIRE(p >= 0.0);
+  AR_REQUIRE(p >= 0.0 && p <= 1.0);
 
   // Lowest error rate that can be represented is 93 (~5e-10), encoded as '~'
   const auto raw_score = p_to_phred(std::max(5e-10, p));
-  return std::min<int>(PHRED_OFFSET_MAX, PHRED_OFFSET_MIN + raw_score);
+  return std::min<int>(PHRED_OFFSET_MAX,
+                       PHRED_OFFSET_MIN +
+                         static_cast<int>(std::round(raw_score)));
 }
 
 } // namespace adapterremoval

--- a/tests/unit/fastq_enc_test.cpp
+++ b/tests/unit/fastq_enc_test.cpp
@@ -45,6 +45,8 @@ TEST_CASE("fastq_encoding::p_to_phred_33")
   CHECK(fastq_encoding::p_to_phred_33(1e-9) == '{');
   // Supports higher phred scores than the 33 encoding
   CHECK(fastq_encoding::p_to_phred_33(1e-10) == '~');
+  // Should be rounded to closest integer
+  CHECK(fastq_encoding::p_to_phred_33(0.2) == '(');
 
   CHECK_THROWS_AS(fastq_encoding::p_to_phred_33(-0.005), assert_failed);
 }


### PR DESCRIPTION
This only affects the Phred encoded quality scores for consensus adapter sequences with --report-only. Also added missing condition in ASSERT