### PR TITLE
fix json encoding of non-printable characters

### DIFF
--- a/src/json.cpp
+++ b/src/json.cpp
@@ -4,11 +4,14 @@
 #include "debug.hpp"    // for AR_REQUIRE
 #include "strutils.hpp" // for join_text, stringify
 #include <cmath>        // for isinf, isnan
+#include <iomanip>      // for setfill, setw
 #include <memory>       // for make_shared, __shared_ptr_access, shar...
 #include <sstream>      // for ostringstream
 #include <utility>      // for pair
 
 namespace adapterremoval {
+
+namespace {
 
 std::string
 _escape(std::string_view value)
@@ -41,10 +44,11 @@ _escape(std::string_view value)
         stream << "\\t";
         break;
       default: {
-        if (c <= 0x1F) {
-          stream << "\\u" << std::hex << static_cast<int>(c);
+        if (c >= 0 && c <= 0x1F) {
+          stream << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+                 << static_cast<unsigned int>(static_cast<unsigned char>(c));
         } else {
-          stream << c;
+          stream.put(c);
         }
       }
     }
@@ -69,6 +73,8 @@ format_f64(double value)
 
   return out.str();
 }
+
+} // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/tests/unit/json_test.cpp
+++ b/tests/unit/json_test.cpp
@@ -10,8 +10,11 @@
 #include <limits>       // for numeric_limits
 #include <sstream>      // for ostringstream
 #include <string>       // for basic_string, operator==, string
+#include <string_view>  // for string_view
 
 namespace adapterremoval {
+
+namespace {
 
 template<typename T>
 std::string
@@ -22,6 +25,8 @@ _write_json(const T& json)
 
   return ss.str();
 }
+
+} // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 // json_token::constructor
@@ -80,6 +85,25 @@ TEST_CASE("special characters are encoded by json_token::from_str")
   auto s = json_token::from_str("\\simple\ttest\n123");
 
   REQUIRE(s->to_string() == "\"\\\\simple\\ttest\\n123\"");
+}
+
+TEST_CASE("unprintable characters are encoded by json_token::from_str")
+{
+  using namespace std::literals;
+
+  CHECK(json_token::from_str("foo\000bar"sv)->to_string() ==
+        "\"foo\\u0000bar\"");
+  CHECK(json_token::from_str("foo\037bar"sv)->to_string() ==
+        "\"foo\\u001fbar\"");
+}
+
+TEST_CASE("unicode should be ignored by json_token::from_str")
+{
+  const std::string_view input =
+    "\xe3\x81\x8b\xe3\x82\x8f\xe3\x81\x84\xe3\x81\x84\xe7\x8c\xab";
+
+  CHECK(json_token::from_str(input)->to_string() ==
+        "\"\xe3\x81\x8b\xe3\x82\x8f\xe3\x81\x84\xe3\x81\x84\xe7\x8c\xab\"");
 }
 
 TEST_CASE("identical to_string and write for json_token::from_str")


### PR DESCRIPTION
- added missing 0-zero padding to \u0000 encoded characters
- fixed mangling of and added tests for UTF-8 encoded input
- fixed sign-extension of negative char values

AdapterRemoval does not support UTF-8 as such, but with this change a properly UTF-8 encoded filename will be preserved in JSON output