### PR TITLE
require virtual destructor in  dynamic_cast_unique

### DIFF
--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -67,6 +67,7 @@ template<typename T, typename U>
 std::unique_ptr<T, std::default_delete<T>>
 dynamic_cast_unique(std::unique_ptr<U, std::default_delete<U>>& src)
 {
+  static_assert(std::has_virtual_destructor_v<T>);
   if (auto* dst = dynamic_cast<T*>(src.get())) {
     std::ignore = src.release();      // noexcept, silence warning
     return std::unique_ptr<T>{ dst }; // noexcept


### PR DESCRIPTION
This prevents undefined behavior on destruction