### PR TITLE
apply min-overlap to PE alignments

### DIFF
--- a/docs/detailed_overview.rst
+++ b/docs/detailed_overview.rst
@@ -52,9 +52,11 @@ Each read and adapter sequence (single-end mode) or each read pair and adapter s
 
 Note that adapter 2 and read 2 are both reverse complemented in the above figure. If multiple adapters are specified using ``--adapter-table``, then alignment is carried out with each adapter or adapter pair, in order to select the single best alignment, if any.
 
-If a valid alignment is found, and if the error rate in the alignment does not exceed the maximum error rate defined by ``--mismatch-rate``, and if the alignment covers at least ``--min-adapter-overlap`` bases for SE data, then the inferred adapter sequences are trimmed.
+If a valid alignment is found, and if the error rate in the alignment does not exceed the maximum error rate defined by ``--mismatch-rate``, and if the alignment involves at least ``--min-overlap`` unambiguous bases (not 'N'), then the inferred adapter sequences are trimmed.
 
-If the ``--merge`` option is set and the best alignment is at least ``--merge-threshold`` long, then the two reads are merged into a single sequence (paired-end mode only). Depending on the ``--merge-strategy`` option, Phred scores of matching merged bases are either set to the maximum of the two observed Phred-scores, or to the sum of Phred scores (the probability that both reads are wrong). The output Phred score is capped by the ``--merge-quality-max``, to ensure that quality scores are compatible with downstream tools.
+In paired-end mode only, if the ``--merge`` option is set and the best alignment is at least ``--merge-threshold`` long, then the two reads are merged into a single sequence. Ambiguous nucleotides (Ns) are not counted as part of the alignment, for the purpose of checking ``--merge-threshold``.
+
+Depending on the ``--merge-strategy`` option, Phred scores of matching merged bases are either set to the maximum of the two observed Phred-scores, or to the sum of Phred scores (the probability that both reads are wrong). The output Phred score is capped by the ``--merge-quality-max``, to ensure that quality scores are compatible with downstream tools.
 
 If the ``--post-trim5p`` or ``--post-trim3p`` options are specified, the reads are trimmed by the specified amounts of bases and poly-X tails are trimmed if the ``--post-trim-polyx`` option is specified. Only trimming with the ``--post-trim5p`` is performed on merged reads, since the 3' ends are typically located inside the reads or correspond to the 5' of the other mate (see alignment above).
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -287,7 +287,7 @@ To manually set these adapters, use the command-line options ``--adapter1 AGATCG
 
 .. tip::
 
-    An ``N`` in an adapter sequence is treated as a wildcard. An ``N`` will align against any other base, including other ``N``s, but does not affect the score of the resulting alignment and are not counted for the purpose of filters such as ``--min-adapter-overlap``.
+    An ``N`` in an adapter sequence is treated as a wildcard. An ``N`` will align against any other base, including other ``N``s, but does not affect the score of the resulting alignment and are not counted for the purpose of filters such as ``--min-overlap``.
 
 .. tip::
 

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -182,9 +182,9 @@ Adapter selection
 FASTQ processing options
 ========================
 
-.. option:: --min-adapter-overlap length
+.. option:: --min-overlap length
 
-    In single-end mode, reads are only trimmed if the overlap between the read and the adapter is at least X bases long, not counting ambiguous nucleotides (N). Defaults to 1.
+    The minimum amount of bases that must overlap, not counting ambiguous nucleotides (Ns), for a single-end or paired-end alignment to be considered valid. For paired-end mode, this is important when no adapters were specified or detected, to prevent trimming of short palindromes. Defaults to 1 in single-end mode, and `--merge-threshold` in paired-end mode.
 
 .. option:: --mismatch-rate rate
 
@@ -201,7 +201,7 @@ FASTQ processing options
 
 .. option:: --merge-threshold length
 
-    The minimum overlap between mate 1 and mate 2 before the reads are merged into one, potentially longer sequence, when merging paired-end reads. Default is 11 bases.
+    The minimum overlap between mate 1 and mate 2 before the reads are merged into one, potentially longer sequence, when merging is enabled. Does not include ambiguous nucleotides (Ns). Default is 11 bases.
 
 .. option:: --merge-strategy name
 

--- a/src/adapter_detector.cpp
+++ b/src/adapter_detector.cpp
@@ -225,7 +225,7 @@ adapter_detector::adapter_detector(adapter_database database,
   , m_aligner(adapters_to_set(m_adapters), is, mismatch_threshold)
   , m_common_prefixes(common_prefixes(m_adapters, ADAPTER_DETECT_MIN_OVERLAP))
 {
-  m_aligner.set_min_se_overlap(ADAPTER_DETECT_MIN_OVERLAP);
+  m_aligner.set_min_overlap(ADAPTER_DETECT_MIN_OVERLAP);
 }
 
 void

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -111,7 +111,7 @@ sequence_aligner::update_flags(alignment_info& alignment,
   // Only pairs of called bases are considered part of the alignment
   const size_t n_aligned = alignment.m_length - alignment.m_n_ambiguous;
 
-  if (alignment.score() > 0 && (paired_end || n_aligned >= m_min_se_overlap)) {
+  if (alignment.score() > 0 && n_aligned >= m_min_overlap) {
     auto mm_threshold = static_cast<size_t>(m_mismatch_threshold * n_aligned);
     if (n_aligned < 6) {
       mm_threshold = 0;
@@ -288,6 +288,20 @@ sequence_aligner::sequence_aligner(const adapter_set& adapters,
   }
 }
 
+void
+sequence_aligner::set_min_overlap(size_t n)
+{
+  AR_REQUIRE(n > 0);
+  m_min_overlap = n;
+}
+
+void
+sequence_aligner::set_merge_threshold(size_t n)
+{
+  AR_REQUIRE(n > 0);
+  m_merge_threshold = n;
+}
+
 alignment_info
 sequence_aligner::align_single_end(const fastq& read, unsigned max_shift)
 {
@@ -380,7 +394,8 @@ sequence_aligner::align_paired_end(const fastq& read1,
 
     // Only check for end/end overlaps during the first alignment; subsequent
     // alignments need only consider offsets involving the current adapters
-    const int max_offset = (adapter_id ? adapter2.length() : sequence1_len) - 1;
+    const int max_offset =
+      static_cast<int>(adapter_id ? adapter2.length() : sequence1_len) - 1;
 
     if (pairwise_align_sequences(alignment,
                                  sequence1,

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -203,11 +203,11 @@ public:
                    simd::instruction_set is,
                    double mismatch_threshold);
 
-  /** Sets the minimum required overlap for "good" SE alignments */
-  void set_min_se_overlap(size_t n) { m_min_se_overlap = n; }
+  /** Sets the minimum required overlap for "good" alignments */
+  void set_min_overlap(size_t n);
 
   /** Sets the minimum number of non-N aligned bases required to merge */
-  void set_merge_threshold(size_t n) { m_merge_threshold = n; }
+  void set_merge_threshold(size_t n);
 
   /**
    * Attempts to align adapters sequences against a SE read.
@@ -282,7 +282,7 @@ private:
   //! Number of aligned (non-N, including adapters) bases required for merging
   size_t m_merge_threshold;
   //! Minimum alignment length for "good" SE alignments, including Ns
-  size_t m_min_se_overlap = 1;
+  size_t m_min_overlap = 1;
   //! PE sequences are assumed to have been trimmed already
   bool m_assume_pretrimmed = false;
 

--- a/src/main_benchmark.cpp
+++ b/src/main_benchmark.cpp
@@ -407,7 +407,7 @@ public:
     , m_adapters(config.samples.get_reader()->adapters())
     , m_aligner(m_adapters, is, config.mismatch_threshold)
   {
-    m_aligner.set_min_se_overlap(config.min_adapter_overlap);
+    m_aligner.set_min_overlap(config.min_overlap);
   }
 
 protected:

--- a/src/main_reports.cpp
+++ b/src/main_reports.cpp
@@ -69,6 +69,7 @@ public:
                                     *m_config.simd.get_reader(),
                                     m_config.mismatch_threshold);
     aligner.set_merge_threshold(m_config.merge_threshold);
+    aligner.set_min_overlap(m_config.min_overlap);
 
     auto stats_id = m_stats_id.acquire();
     auto stats_ins = m_stats_ins.acquire();
@@ -89,18 +90,19 @@ public:
 
       if (alignment.type() >= alignment_type::good) {
         stats_id->aligned_pairs++;
+
         if (alignment.type() == alignment_type::mergeable) {
           const size_t insert_size = alignment.insert_size(read_1, read_2);
           stats_ins->insert_sizes.resize_up_to(insert_size + 1);
           stats_ins->insert_sizes.inc(insert_size);
+        }
 
-          if (alignment.extract_adapter_sequences(read_1, read_2)) {
-            stats_id->pairs_with_adapters++;
+        if (alignment.extract_adapter_sequences(read_1, read_2)) {
+          stats_id->pairs_with_adapters++;
 
-            stats_id->adapter1.process(read_1.sequence());
-            read_2.reverse_complement();
-            stats_id->adapter2.process(read_2.sequence());
-          }
+          stats_id->adapter1.process(read_1.sequence());
+          read_2.reverse_complement();
+          stats_id->adapter2.process(read_2.sequence());
         }
       }
     }

--- a/src/trimming.cpp
+++ b/src/trimming.cpp
@@ -307,7 +307,7 @@ se_reads_processor::process(chunk_ptr data)
   const auto simd = *m_config.simd.get_reader();
   for (const auto& it : samples->at(m_sample)) {
     aligners.emplace_back(it.adapters(), simd, m_config.mismatch_threshold);
-    aligners.back().set_min_se_overlap(m_config.min_adapter_overlap);
+    aligners.back().set_min_overlap(m_config.min_overlap);
   }
 
   AR_REQUIRE(!aligners.empty());
@@ -441,6 +441,7 @@ pe_reads_processor::process(chunk_ptr data)
   for (const auto& it : sample) {
     aligners.emplace_back(it.adapters(), simd, m_config.mismatch_threshold);
     aligners.back().set_merge_threshold(m_config.merge_threshold);
+    aligners.back().set_min_overlap(m_config.min_overlap);
   }
 
   // Read processing statistics

--- a/src/userconfig.cpp
+++ b/src/userconfig.cpp
@@ -919,12 +919,14 @@ userconfig::userconfig()
   argparser.add_header("PROCESSING:");
 
   argparser.add_separator();
-  argparser.add("--min-adapter-overlap", "N")
-    .help("In single-end mode, reads are only trimmed if the overlap between "
-          "read and the adapter is at least X bases long, not counting "
-          "ambiguous nucleotides (Ns)")
+  argparser.add("--min-overlap", "N")
+    .help("The minimum amount of bases that must overlap, not counting "
+          "ambiguous nucleotides (Ns), for a single-end or paired-end "
+          "alignment to be considered valid [default: 1 in single-end mode, "
+          "--merge-threshold for paired-end mode]")
     .deprecated_alias("--minadapteroverlap")
-    .bind_u32(&min_adapter_overlap)
+    .deprecated_alias("--min-adapter-overlap")
+    .bind_u32(&min_overlap)
     .with_default(1)
     .with_minimum(1);
   argparser.add("--mismatch-rate", "X")
@@ -951,7 +953,8 @@ userconfig::userconfig()
           "where one or both bases are ambiguous (N) are not counted")
     .deprecated_alias("--minalignmentlength")
     .bind_u32(&merge_threshold)
-    .with_default(11);
+    .with_default(11)
+    .with_minimum(1);
   argparser.add("--merge-strategy", "X")
     .help(
       "The 'maximum' strategy uses Q=max(Q1,Q2) for matches while the "
@@ -1448,6 +1451,10 @@ userconfig::parse_args(const string_vec& argvec)
         AR_FAIL(strategy);
       }
     }
+  }
+
+  if (!argparser.is_set("--min-overlap")) {
+    min_overlap = paired_ended_mode ? merge_threshold : 1;
   }
 
   // (Optionally) read barcodes from file and validate. Must be done before

--- a/src/userconfig.hpp
+++ b/src/userconfig.hpp
@@ -103,8 +103,8 @@ public:
   uint32_t min_genomic_length{};
   //! The maximum length of trimmed reads (ie. genomic nts) to be retained
   uint32_t max_genomic_length{};
-  //! The minimum required overlap before trimming single-end reads.
-  uint32_t min_adapter_overlap{};
+  //! The minimum required overlap before trimming reads.
+  uint32_t min_overlap{};
   //! Rate of mismatches determining the threshold for an acceptable alignment,
   //! depending on the length of the alignment. But see also the limits set in
   //! the function 'is_good_alignment'.

--- a/tests/regression/misc/qualityformat/sam/report_pe.json
+++ b/tests/regression/misc/qualityformat/sam/report_pe.json
@@ -73,7 +73,7 @@
     "duplication": null,
     "insert_sizes": [],
     "consensus_adapters": {
-      "aligned_pairs": 1,
+      "aligned_pairs": 0,
       "pairs_with_adapters": 0,
       "read1": {
         "consensus": "",

--- a/tests/unit/alignment_test.cpp
+++ b/tests/unit/alignment_test.cpp
@@ -851,23 +851,30 @@ TEST_CASE("Positive score is required for good alignment", "[alignment:flags]")
   }
 }
 
-TEST_CASE("Single end with minimum overlap", "[alignment:flags]")
+TEST_CASE("Alignment with minimum overlap", "[alignment:flags]")
 {
   const adapter_set adapters{ { "ATGC", "CCCC" } };
   sequence_aligner aligner{ adapters, PARAMETERIZE_IS, 1.0 };
-  aligner.set_min_se_overlap(2);
+  aligner.set_min_overlap(2);
 
-  SECTION("does not affect PE")
+  SECTION("PE length 1 is too short")
   {
     const auto result =
-      aligner.align_paired_end({ "Read", "AT" }, { "Read", "TA" }, 0);
-    REQUIRE(result == ALN().offset(1).length(1).is_good());
+      aligner.align_paired_end({ "Read", "T" }, { "Read", "T" }, 0);
+    REQUIRE(result == ALN().offset(0).length(1));
   }
 
   SECTION("SE length 1 too short")
   {
     const auto result = aligner.align_single_end({ "Read", "CGTA" }, 0);
     REQUIRE(result == ALN().offset(3).length(1));
+  }
+
+  SECTION("PE length 2 is long enough")
+  {
+    const auto result =
+      aligner.align_paired_end({ "Read", "TAT" }, { "Read", "ATG" }, 0);
+    REQUIRE(result == ALN().offset(1).length(2).is_good());
   }
 
   SECTION("SE length 2 long enough")
@@ -880,6 +887,13 @@ TEST_CASE("Single end with minimum overlap", "[alignment:flags]")
   {
     const auto result = aligner.align_single_end({ "Read", "CATG" }, 0);
     REQUIRE(result == ALN().offset(1).length(3).is_good());
+  }
+
+  SECTION("PE length 3 is long enough")
+  {
+    const auto result =
+      aligner.align_paired_end({ "Read", "ATTAG" }, { "Read", "TAGCG" }, 0);
+    REQUIRE(result == ALN().offset(2).length(3).is_good());
   }
 }
 
@@ -981,8 +995,7 @@ TEST_CASE("can_merge requires good alignment", "[alignment:flags]")
 
   SECTION("can merge when threshold less-than-or-equal")
   {
-    // A threshold of 0 is functionally identical to 1
-    aligner.set_merge_threshold(GENERATE(0, 1, 2, 3, 4, 5, 6));
+    aligner.set_merge_threshold(GENERATE(1, 2, 3, 4, 5, 6));
     const auto result = aligner.align_paired_end(read1, read2, 0);
     REQUIRE(result == ALN().offset(2).length(6).can_merge());
   }


### PR DESCRIPTION
- Renamed `--min-adapter-overlap` to `--min-overlap`
- Applied `--min-overlap` to both SE and PE alignments
- Use min-overlap as filter when building consensus adapters
- Set PE specific default for --min-overlap