### PR TITLE
drop forwarding of arguments in emplace_back_n

### DIFF
--- a/src/threading.hpp
+++ b/src/threading.hpp
@@ -37,11 +37,11 @@ public:
 
   /** Create N new state values using the given arguments **/
   template<class... Args>
-  void emplace_back_n(size_t n, Args&&... args)
+  void emplace_back_n(size_t n, const Args&... args)
   {
     std::lock_guard<std::mutex> lock(m_mutex);
     for (; n; n--) {
-      m_values.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));
+      m_values.emplace_back(std::make_unique<T>(args...));
     }
   }
 

--- a/tests/unit/threading_test.cpp
+++ b/tests/unit/threading_test.cpp
@@ -87,6 +87,20 @@ TEST_CASE("threadstate emplace back n", "[scheduler::threadstate]")
   REQUIRE_THROWS_AS(state.acquire(), assert_failed);
 }
 
+TEST_CASE("threadstate emplace back n (moved)", "[scheduler::threadstate]")
+{
+  threadstate<std::string> state;
+  state.emplace_back_n(3, std::string{ __PRETTY_FUNCTION__ });
+
+  for (size_t i = 0; i < 3; ++i) {
+    auto value = state.acquire();
+    REQUIRE(value);
+    REQUIRE(*value == __PRETTY_FUNCTION__);
+  }
+
+  REQUIRE_THROWS_AS(state.acquire(), assert_failed);
+}
+
 TEST_CASE("threadstate release", "[scheduler::threadstate]")
 {
   threadstate<int> state;


### PR DESCRIPTION
This breaks for movable variables, such as strings