### PR TITLE
re-use input FASTQ vectors

### DIFF
--- a/src/demultiplexing.cpp
+++ b/src/demultiplexing.cpp
@@ -6,6 +6,7 @@
 #include "commontypes.hpp"    // for read_type, read_file
 #include "debug.hpp"          // for AR_REQUIRE, AR_REQUIRE_SINGLE_THREAD
 #include "fastq.hpp"          // for fastq
+#include "fastq_io.hpp"       // for read_fastq
 #include "output.hpp"         // for output_files
 #include "scheduler.hpp"      // for fastq_chunk
 #include "sequence_sets.hpp"  // for adapter_set
@@ -93,6 +94,8 @@ demultiplex_se_reads::process(chunk_ptr data)
     }
   }
 
+  read_fastq::release(std::move(chunk->reads_1));
+
   return m_cache.flush(chunk->eof, chunk->mate_separator);
 }
 
@@ -143,6 +146,9 @@ demultiplex_pe_reads::process(chunk_ptr data)
       m_statistics->samples.at(sample).inc(barcode, 2);
     }
   }
+
+  read_fastq::release(std::move(chunk->reads_1));
+  read_fastq::release(std::move(chunk->reads_2));
 
   return m_cache.flush(chunk->eof, chunk->mate_separator);
 }

--- a/src/fastq_io.cpp
+++ b/src/fastq_io.cpp
@@ -296,7 +296,7 @@ read_fastq::read_interleaved(std::vector<fastq>& reads_1,
 {
   AR_REQUIRE(reads_1.empty() && reads_2.empty());
 
-  const size_t to_read = std::min(INPUT_READS, m_head);
+  const size_t to_read = std::min<size_t>(INPUT_READS, m_head);
   s_fastq_vec_cache.acquire(reads_1, to_read);
   s_fastq_vec_cache.acquire(reads_2, to_read);
 

--- a/src/fastq_io.cpp
+++ b/src/fastq_io.cpp
@@ -275,7 +275,7 @@ read_fastq::read_single_end(std::vector<fastq>& reads)
 {
   AR_REQUIRE(reads.empty());
 
-  const size_t to_read = std::min(INPUT_READS, m_head);
+  const size_t to_read = std::min<size_t>(INPUT_READS, m_head);
   s_fastq_vec_cache.acquire(reads, to_read);
 
   size_t nread = 0;

--- a/src/fastq_io.cpp
+++ b/src/fastq_io.cpp
@@ -87,22 +87,14 @@ enum class read_fastq::file_type
 namespace {
 
 bool
-read_record(joined_line_readers& reader, std::vector<fastq>& chunk)
+read_record(joined_line_readers& reader, fastq& record)
 {
   // Line numbers change as we attempt to read the record, and potentially
   // points to the next record in the case of invalid qualities/nucleotides
   const auto start = reader.linenumber();
 
   try {
-    chunk.emplace_back();
-    auto& record = chunk.back();
-
-    if (record.read_unsafe(reader)) {
-      return true;
-    } else {
-      chunk.pop_back();
-      return false;
-    }
+    return record.read_unsafe(reader);
   } catch (const fastq_error& error) {
     std::ostringstream stream;
     stream << "Error reading FASTQ record from "
@@ -140,6 +132,62 @@ estimate_capacity(size_t input_size, bool eof)
          + (eof ? BGZF_EOF.size() : 0) // Standard bgzip tail
     ;
 }
+
+class fastq_vec_cache
+{
+public:
+  fastq_vec_cache() = default;
+  fastq_vec_cache(const fastq_vec_cache&) = delete;
+  fastq_vec_cache(fastq_vec_cache&&) = delete;
+  fastq_vec_cache& operator=(const fastq_vec_cache&) = delete;
+  fastq_vec_cache& operator=(fastq_vec_cache&&) = delete;
+  ~fastq_vec_cache() = default;
+
+  /** Attempt to acquire a previously used vector of fastq objects */
+  void acquire(std::vector<fastq>& chunk, size_t capacity)
+  {
+    if (capacity) {
+      std::unique_lock<std::mutex> lock{ s_chunks_lock };
+      if (s_chunks_cache.empty()) {
+        s_chunks_created++;
+      } else {
+        chunk = std::move(s_chunks_cache.back());
+        s_chunks_cache.pop_back();
+      }
+    }
+
+    chunk.resize(capacity);
+  }
+
+  /** Release a vector of fastq objects for reuse */
+  void release(std::vector<fastq>&& chunk)
+  {
+    if (chunk.capacity()) {
+      std::unique_lock<std::mutex> lock{ s_chunks_lock };
+      s_chunks_cache.emplace_back(std::move(chunk));
+    }
+  }
+
+  /** Verify that there were no leaks or lost chunks */
+  void finalize()
+  {
+    std::unique_lock<std::mutex> lock{ s_chunks_lock };
+    AR_REQUIRE(s_chunks_cache.size() == s_chunks_created);
+    s_chunks_cache.clear();
+    s_chunks_created = 0;
+  }
+
+private:
+  //! Lock used to control access to cache of previously allocated FASTQ chunks
+  std::mutex s_chunks_lock{};
+  //! Cache of FASTQ chunks that have previously been returned by `release`
+  std::vector<std::vector<fastq>> s_chunks_cache{};
+  //! #chunks created, to check that `release` and `acquire` are called 1-to-1
+  size_t s_chunks_created = 0;
+};
+
+//! Global cache of FASTQ vectors, used to reduce the number of allocs
+fastq_vec_cache s_fastq_vec_cache;
 
 } // namespace
 
@@ -225,25 +273,47 @@ read_fastq::process(chunk_ptr data)
 void
 read_fastq::read_single_end(std::vector<fastq>& reads)
 {
-  for (; reads.size() < INPUT_READS && m_head && !m_eof; m_head--) {
-    if (!read_record(m_reader, reads)) {
+  AR_REQUIRE(reads.empty());
+
+  const size_t to_read = std::min(INPUT_READS, m_head);
+  s_fastq_vec_cache.acquire(reads, to_read);
+
+  size_t nread = 0;
+  for (; nread < to_read; ++nread) {
+    if (!read_record(m_reader, reads.at(nread))) {
       m_eof = true;
+      break;
     }
   }
+
+  m_head -= nread;
+  reads.resize(nread);
 }
 
 void
 read_fastq::read_interleaved(std::vector<fastq>& reads_1,
                              std::vector<fastq>& reads_2)
 {
-  for (; reads_1.size() < INPUT_READS && m_head && !m_eof; m_head--) {
-    if (!read_record(m_reader, reads_1)) {
+  AR_REQUIRE(reads_1.empty() && reads_2.empty());
+
+  const size_t to_read = std::min(INPUT_READS, m_head);
+  s_fastq_vec_cache.acquire(reads_1, to_read);
+  s_fastq_vec_cache.acquire(reads_2, to_read);
+
+  size_t nread = 0;
+  for (; nread < to_read; ++nread) {
+    if (!read_record(m_reader, reads_1.at(nread))) {
       m_eof = true;
       break;
+    } else if (!read_record(m_reader, reads_2.at(nread))) {
+      throw fastq_error("Found uneven number of interleaved reads; input files "
+                        " may be truncated. Please fix before continuing.");
     }
-
-    read_record(m_reader, reads_2);
   }
+
+  m_head -= nread;
+  reads_1.resize(nread);
+  reads_2.resize(nread);
 }
 
 void
@@ -251,6 +321,14 @@ read_fastq::finalize()
 {
   AR_REQUIRE_SINGLE_THREAD(m_lock);
   AR_REQUIRE(m_eof);
+
+  s_fastq_vec_cache.finalize();
+}
+
+void
+read_fastq::release(std::vector<fastq>&& chunk)
+{
+  s_fastq_vec_cache.release(std::move(chunk));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/fastq_io.hpp
+++ b/src/fastq_io.hpp
@@ -64,6 +64,9 @@ public:
   /** Finalizer; checks that all input has been processed. */
   void finalize() override;
 
+  /** Release a vector of fastq objects for reuse */
+  static void release(std::vector<fastq>&& chunk);
+
   read_fastq(const read_fastq&) = delete;
   read_fastq(read_fastq&&) = delete;
   read_fastq& operator=(const read_fastq&) = delete;

--- a/src/main_reports.cpp
+++ b/src/main_reports.cpp
@@ -35,7 +35,16 @@ public:
   {
   }
 
-  chunk_vec process(chunk_ptr /* chunk */) override { return {}; }
+  chunk_vec process(chunk_ptr data) override
+  {
+    auto chunk = dynamic_cast_unique<fastq_chunk>(data);
+    AR_REQUIRE(chunk);
+
+    read_fastq::release(std::move(chunk->reads_1));
+    read_fastq::release(std::move(chunk->reads_2));
+
+    return {};
+  }
 };
 
 class adapter_identification : public analytical_step
@@ -109,6 +118,9 @@ public:
 
     m_stats_id.release(std::move(stats_id));
     m_stats_ins.release(std::move(stats_ins));
+
+    read_fastq::release(std::move(chunk->reads_1));
+    read_fastq::release(std::move(chunk->reads_2));
 
     return {};
   }

--- a/src/trimming.cpp
+++ b/src/trimming.cpp
@@ -7,7 +7,7 @@
 #include "counts.hpp"        // for counts, indexed_count
 #include "debug.hpp"         // for AR_FAIL, AR_REQUIRE
 #include "fastq.hpp"         // for fastq
-#include "fastq_enc.hpp"     // for ACGT
+#include "fastq_io.hpp"      // for read_fastq
 #include "output.hpp"        // for sample_output_files, processed_reads
 #include "scheduler.hpp"     // for analytical_step, processing_order
 #include "sequence_sets.hpp" // for adapter_set
@@ -362,6 +362,11 @@ se_reads_processor::process(chunk_ptr data)
 
   m_stats.release(std::move(stats));
 
+  // avoid adding non-input chunks to the cache
+  if (!m_config.is_demultiplexing_enabled()) {
+    read_fastq::release(std::move(chunk->reads_1));
+  }
+
   return chunks.finalize(chunk->eof);
 }
 
@@ -605,6 +610,12 @@ pe_reads_processor::process(chunk_ptr data)
   stats->ns_resolved += merger.ns_resolved();
 
   m_stats.release(std::move(stats));
+
+  // avoid adding non-input chunks to the cache
+  if (!m_config.is_demultiplexing_enabled()) {
+    read_fastq::release(std::move(chunk->reads_1));
+    read_fastq::release(std::move(chunk->reads_2));
+  }
 
   return chunks.finalize(chunk->eof);
 }


### PR DESCRIPTION
This significantly increases maximum throughput, though this is mainly observable for uncompressed/STDIN input