### PR TITLE
improvements to asserts

### DIFF
--- a/src/debug.hpp
+++ b/src/debug.hpp
@@ -19,8 +19,8 @@ debug_raise_assert(std::string_view funcname,
 
 #ifdef __has_builtin
 #if __has_builtin(__builtin_expect)
-#define AR_LIKELY(condition) __builtin_expect(!!(condition), 1)
-#define AR_UNLIKELY(condition) __builtin_expect(!!(condition), 0)
+#define AR_LIKELY(condition) __builtin_expect(static_cast<bool>(condition), 1)
+#define AR_UNLIKELY(condition) __builtin_expect(static_cast<bool>(condition), 0)
 #endif
 #endif
 
@@ -32,8 +32,7 @@ debug_raise_assert(std::string_view funcname,
 /** Custom assert which prints various information on failure; always enabled */
 #define AR_REQUIRE_2_(test, msg)                                               \
   do {                                                                         \
-    /* NOLINTNEXTLINE(readability-simplify-boolean-expr) */                    \
-    if (AR_UNLIKELY(!(test))) {                                                \
+    if (!AR_LIKELY(test)) {                                                    \
       ::adapterremoval::debug_raise_assert(__PRETTY_FUNCTION__,                \
                                            __FILE__,                           \
                                            __LINE__,                           \
@@ -59,12 +58,13 @@ debug_raise_assert(std::string_view funcname,
 #define AR_MERGE1_(a, b) a##b
 #define AR_MERGE_(a, b) AR_MERGE1_(a, b)
 
-/** Raise a failure if a scope is accessed more than once at the same time. */
+/** Raise a failure if scope is accessed by multiple threads simultaneously */
 #define AR_REQUIRE_SINGLE_THREAD(lock)                                         \
-  std::unique_lock<std::mutex> AR_MERGE_(locker, __LINE__)(lock,               \
-                                                           std::defer_lock);   \
+  std::unique_lock<std::recursive_mutex> AR_MERGE_(locker,                     \
+                                                   __LINE__)(lock,             \
+                                                             std::defer_lock); \
   do {                                                                         \
-    if (AR_UNLIKELY(!AR_MERGE_(locker, __LINE__).try_lock())) {                \
+    if (!AR_LIKELY(AR_MERGE_(locker, __LINE__).try_lock())) {                  \
       AR_FAIL("race condition detected");                                      \
     }                                                                          \
   } while (0)

--- a/src/demultiplexing.hpp
+++ b/src/demultiplexing.hpp
@@ -59,7 +59,7 @@ protected:
   demux_stats_ptr m_statistics{};
 
   //! Lock used to verify that the analytical_step is only run sequentially.
-  std::mutex m_lock{};
+  std::recursive_mutex m_lock{};
 };
 
 /** Demultiplexer for single-end reads. */

--- a/src/fastq_io.cpp
+++ b/src/fastq_io.cpp
@@ -492,7 +492,7 @@ post_process_fastq::process(chunk_ptr data)
   m_stats.release(std::move(stats));
 
   {
-    std::unique_lock<std::mutex> lock(m_timer_lock);
+    std::unique_lock<std::recursive_mutex> lock(m_timer_lock);
     m_timer->increment(reads_1.size() + reads_2.size());
   }
 

--- a/src/fastq_io.hpp
+++ b/src/fastq_io.hpp
@@ -94,7 +94,7 @@ private:
   uint64_t m_head = std::numeric_limits<uint64_t>::max();
 
   //! Lock used to verify that the analytical_step is only run sequentially.
-  std::mutex m_lock{};
+  std::recursive_mutex m_lock{};
 };
 
 /** Step for performing costly, ordered (duplication) analysis */
@@ -184,7 +184,7 @@ private:
   const fastq_encoding m_encoding;
 
   //! Lock used to control access to progress timer
-  std::mutex m_timer_lock{};
+  std::recursive_mutex m_timer_lock{};
   //! Timer for displaying read progress.
   std::unique_ptr<progress_timer> m_timer;
 };
@@ -225,7 +225,7 @@ private:
   bool m_eof = false;
 
   //! Lock used to verify that the analytical_step is only run sequentially.
-  std::mutex m_lock{};
+  std::recursive_mutex m_lock{};
 };
 
 /**
@@ -290,7 +290,7 @@ private:
   bool m_eof = false;
 
   //! Lock used to verify that the analytical_step is only run sequentially.
-  std::mutex m_lock{};
+  std::recursive_mutex m_lock{};
 };
 
 } // namespace adapterremoval

--- a/tests/unit/debug_test.cpp
+++ b/tests/unit/debug_test.cpp
@@ -6,6 +6,7 @@
 #include <mutex>       // for unique_lock, mutex
 #include <sstream>     // for operator<<, basic_ostream, char_traits, ostring...
 #include <string>      // for basic_string, operator==, string
+#include <thread>      // for thread
 
 namespace adapterremoval {
 
@@ -71,7 +72,7 @@ TEST_CASE("assert fail")
 
 TEST_CASE("assert single thread")
 {
-  std::mutex lock;
+  std::recursive_mutex lock;
 
   {
     AR_REQUIRE_SINGLE_THREAD(lock);
@@ -84,16 +85,25 @@ TEST_CASE("assert single thread")
 
 TEST_CASE("assert single thread failed")
 {
-  std::mutex lock;
-
+  std::recursive_mutex lock;
   AR_REQUIRE_SINGLE_THREAD(lock);
 
-  bool caught_exception = false;
-  try {
+  {
+    // The same thread is allowed to re-enter the scope
     AR_REQUIRE_SINGLE_THREAD(lock);
-  } catch (const assert_failed&) {
-    caught_exception = true;
   }
+
+  bool caught_exception = false;
+  const auto func = [&lock, &caught_exception]() {
+    try {
+      AR_REQUIRE_SINGLE_THREAD(lock);
+    } catch (const assert_failed&) {
+      caught_exception = true;
+    }
+  };
+
+  std::thread thread{ func };
+  thread.join();
 
   REQUIRE(caught_exception);
 }


### PR DESCRIPTION
- Use casts and simplify logic to eliminate warnings/lints
- avoid undefined behavior in AR_REQUIRE_SINGLE_THREAD, if used in a recursive context