### PR TITLE
distinguish better between failures and bugs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         args: [--branch, main, --branch, 2.3.x]
       - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: a8c7c3ac16eabd3b958952ea0d6bf1dceeab6411 # v19.1.2
+    rev: cd481d7b0bfb5c7b3090c21846317f9a8262e891 # v22.1.0
     hooks:
       - id: clang-format
         types_or: [c++, c]

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2015 Mikkel Schubert <mikkelsch@gmail.com>
 #include "debug.hpp" // declarations
-#include "main.hpp"  // for terminate
 #include <sstream>   // for ostringstream
 
 namespace adapterremoval {
 
 [[noreturn]] void
-debug_raise_assert(std::string_view funcname,
-                   std::string_view filename,
-                   unsigned lineno,
-                   std::string_view test,
-                   std::string_view msg)
+terminate_on_assert(std::string_view funcname,
+                    std::string_view filename,
+                    unsigned lineno,
+                    std::string_view test,
+                    std::string_view msg)
 {
   std::ostringstream message;
 
@@ -25,7 +24,7 @@ debug_raise_assert(std::string_view funcname,
     message << ": " << msg;
   }
 
-  terminate(message.str());
+  terminate_on_bug(message.str());
 }
 
 } // namespace adapterremoval

--- a/src/debug.hpp
+++ b/src/debug.hpp
@@ -2,20 +2,30 @@
 // SPDX-FileCopyrightText: 2015 Mikkel Schubert <mikkelsch@gmail.com>
 #pragma once
 
+#include <mutex>       // for recursive_mutex
 #include <string_view> // for string_view
 
 namespace adapterremoval {
 
-/**
- * Aborts after printing the filename, line-number, and message, plus
- * instructions for how to report the problem.
- */
+/** Terminate on internal error; prints how to file issue on github */
 [[noreturn]] void
-debug_raise_assert(std::string_view funcname,
-                   std::string_view filename,
-                   unsigned lineno,
-                   std::string_view test,
-                   std::string_view msg);
+terminate_on_bug(std::string_view message);
+
+/** Terminate on external error; prints warning not to use program output */
+[[noreturn]] void
+terminate_on_failure(std::string_view message);
+
+/** Terminate on unhandled exception */
+[[noreturn]] void
+terminate_on_exception();
+
+/** Terminate on failed assert; prints location and how to file issue */
+[[noreturn]] void
+terminate_on_assert(std::string_view funcname,
+                    std::string_view filename,
+                    unsigned lineno,
+                    std::string_view test,
+                    std::string_view msg);
 
 #ifdef __has_builtin
 #if __has_builtin(__builtin_expect)
@@ -33,11 +43,11 @@ debug_raise_assert(std::string_view funcname,
 #define AR_REQUIRE_2_(test, msg)                                               \
   do {                                                                         \
     if (!AR_LIKELY(test)) {                                                    \
-      ::adapterremoval::debug_raise_assert(__PRETTY_FUNCTION__,                \
-                                           __FILE__,                           \
-                                           __LINE__,                           \
-                                           #test,                              \
-                                           msg);                               \
+      ::adapterremoval::terminate_on_assert(__PRETTY_FUNCTION__,               \
+                                            __FILE__,                          \
+                                            __LINE__,                          \
+                                            #test,                             \
+                                            msg);                              \
     }                                                                          \
   } while (0)
 
@@ -49,11 +59,11 @@ debug_raise_assert(std::string_view funcname,
 
 /** Raise an assert failure with a user-specified message. */
 #define AR_FAIL(msg)                                                           \
-  ::adapterremoval::debug_raise_assert(__PRETTY_FUNCTION__,                    \
-                                       __FILE__,                               \
-                                       __LINE__,                               \
-                                       {},                                     \
-                                       msg)
+  ::adapterremoval::terminate_on_assert(__PRETTY_FUNCTION__,                   \
+                                        __FILE__,                              \
+                                        __LINE__,                              \
+                                        {},                                    \
+                                        msg)
 
 #define AR_MERGE1_(a, b) a##b
 #define AR_MERGE_(a, b) AR_MERGE1_(a, b)
@@ -67,6 +77,8 @@ debug_raise_assert(std::string_view funcname,
     if (!AR_LIKELY(AR_MERGE_(locker, __LINE__).try_lock())) {                  \
       AR_FAIL("race condition detected");                                      \
     }                                                                          \
-  } while (0)
+  } while (0);                                                                 \
+  /* Ensure that this macro cannot be placed after if or while without {} */   \
+  [[maybe_unused]] int AR_MERGE_(_braces_are_required, __LINE__)
 
 } // namespace adapterremoval

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -3,10 +3,10 @@
 #include "errors.hpp"   // declarations
 #include "strutils.hpp" // for log_escape, stringify
 #include <array>        // for array
-#include <cstdio>       // for sys_errlist, sys_nerr
 #include <cstring>      // for strerror_r
 #include <exception>    // for exception
 #include <ostream>      // for ostream
+#include <sstream>      // for ostringstream
 #include <stdexcept>    // for logic_error, runtime_error
 #include <string>       // for string
 #include <string_view>  // for string_view
@@ -86,62 +86,18 @@ assert_failed::assert_failed(const std::string& what)
 {
 }
 
-io_error::io_error(const std::string& message)
+program_failure::program_failure(const std::string& message)
   : std::runtime_error(message)
+{
+}
+
+io_error::io_error(const std::string& message)
+  : program_failure(message)
 {
 }
 
 io_error::io_error(const std::string& message, int error_number)
-  : std::runtime_error(format_io_error(message, error_number))
-{
-}
-
-std::ostream&
-io_error::to_stream(std::ostream& os) const
-{
-  return format_exception(os, "io_error", *this);
-}
-
-gzip_error::gzip_error(const std::string& message)
-  : io_error(message)
-{
-}
-
-std::ostream&
-gzip_error::to_stream(std::ostream& os) const
-{
-  return format_exception(os, "gzip_error", *this);
-}
-
-parsing_error::parsing_error(const std::string& message)
-  : std::runtime_error(message)
-{
-}
-
-std::ostream&
-parsing_error::to_stream(std::ostream& os) const
-{
-  return format_exception(os, "parsing_error", *this);
-}
-
-serializing_error::serializing_error(const std::string& message)
-  : std::runtime_error(message)
-{
-}
-
-fastq_error::fastq_error(const std::string& message)
-  : parsing_error(message)
-{
-}
-
-std::ostream&
-fastq_error::to_stream(std::ostream& os) const
-{
-  return format_exception(os, "fastq_error", *this);
-}
-
-fatal_error::fatal_error(const std::string& message)
-  : std::runtime_error(message)
+  : program_failure(format_io_error(message, error_number))
 {
 }
 
@@ -152,27 +108,9 @@ operator<<(std::ostream& os, const assert_failed& value)
 }
 
 std::ostream&
-operator<<(std::ostream& os, const io_error& value)
+operator<<(std::ostream& os, const program_failure& value)
 {
-  return value.to_stream(os);
-}
-
-std::ostream&
-operator<<(std::ostream& os, const parsing_error& value)
-{
-  return value.to_stream(os);
-}
-
-std::ostream&
-operator<<(std::ostream& os, const serializing_error& value)
-{
-  return format_exception(os, "serializing_error", value);
-}
-
-std::ostream&
-operator<<(std::ostream& os, const fatal_error& value)
-{
-  return format_exception(os, "fatal_error", value);
+  return format_exception(os, value.kind(), value);
 }
 
 } // namespace adapterremoval

--- a/src/errors.hpp
+++ b/src/errors.hpp
@@ -22,8 +22,37 @@ public:
   friend std::ostream& operator<<(std::ostream& os, const assert_failed& value);
 };
 
+/** Base class for errors that should not represent bugs in the program */
+class program_failure : public std::runtime_error
+{
+public:
+  /** Produces an error without an associated error code */
+  explicit program_failure(const std::string& message);
+
+  /** Generic stream functions for program failure sub-classes */
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const program_failure& value);
+
+protected:
+  //! The specific kind of error
+  [[nodiscard]] virtual std::string_view kind() const = 0;
+};
+
+#define AR_DEFINE_FAILURE_FROM(subclass, name)                                 \
+  class name : public subclass /** NOLINT(bugprone-macro-parentheses) */       \
+  {                                                                            \
+  public:                                                                      \
+    explicit name(const std::string& message)                                  \
+      : subclass(message)                                                      \
+    {                                                                          \
+    }                                                                          \
+                                                                               \
+  protected:                                                                   \
+    [[nodiscard]] std::string_view kind() const override { return #name; }     \
+  };
+
 /** Represents errors during basic IO. */
-class io_error : public std::runtime_error
+class io_error : public program_failure
 {
 public:
   /** Produces an error without an associated error code */
@@ -32,61 +61,23 @@ public:
   /** Produces a combined error including a description of the error code */
   explicit io_error(const std::string& message, int error_number);
 
-  friend std::ostream& operator<<(std::ostream& os, const io_error& value);
-
 protected:
-  virtual std::ostream& to_stream(std::ostream& os) const;
+  [[nodiscard]] std::string_view kind() const override { return "io_error"; }
 };
 
 /** Represents errors during GZip (de)compression. */
-class gzip_error : public io_error
-{
-public:
-  explicit gzip_error(const std::string& message);
-
-protected:
-  std::ostream& to_stream(std::ostream& os) const override;
-};
+AR_DEFINE_FAILURE_FROM(io_error, gzip_error);
 
 /** Exception raised for parsing and validation errors. */
-class parsing_error : public std::runtime_error
-{
-public:
-  explicit parsing_error(const std::string& message);
+AR_DEFINE_FAILURE_FROM(program_failure, parsing_error);
 
-  friend std::ostream& operator<<(std::ostream& os, const parsing_error& value);
-
-protected:
-  virtual std::ostream& to_stream(std::ostream& os) const;
-};
-
-/** Exception raised for for errors during serialization / encoding. */
-class serializing_error : public std::runtime_error
-{
-public:
-  explicit serializing_error(const std::string& message);
-
-  friend std::ostream& operator<<(std::ostream& os,
-                                  const serializing_error& value);
-};
+/** Exception raised for errors during serialization / encoding. */
+AR_DEFINE_FAILURE_FROM(program_failure, serializing_error);
 
 /** Exception raised for FASTQ parsing and validation errors. */
-class fastq_error : public parsing_error
-{
-public:
-  explicit fastq_error(const std::string& message);
-
-protected:
-  std::ostream& to_stream(std::ostream& os) const override;
-};
+AR_DEFINE_FAILURE_FROM(parsing_error, fastq_error);
 
 /** Exception raised to trigger a generic (testable) fatal error */
-class fatal_error : public std::runtime_error
-{
-public:
-  explicit fatal_error(const std::string& message);
-
-  friend std::ostream& operator<<(std::ostream& os, const fatal_error& value);
-};
+AR_DEFINE_FAILURE_FROM(program_failure, fatal_error);
 
 } // namespace adapterremoval

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,32 +3,54 @@
 // SPDX-FileCopyrightText: 2014 Mikkel Schubert <mikkelsch@gmail.com>
 #include "main.hpp"       // declarations
 #include "argparse.hpp"   // for parse_result, parse_result::error, parse_...
-#include "debug.hpp"      // for AR_FAIL
+#include "debug.hpp"      // for AR_FAIL, terminate_on_exception
+#include "errors.hpp"     // for assert_failed, program_failure
 #include "logging.hpp"    // for log_stream, error
 #include "reports.hpp"    // for print_terminal_postamble, print_terminal_...
 #include "userconfig.hpp" // for ar_command, userconfig, ar_command::demul...
 #include "version.hpp"    // for version
-#include <cstdlib>        // for abort, size_t
+#include <cstdlib>        // for abort, size_t, quick_exit
 #include <exception>      // for set_terminate
+#include <filesystem>     // for filesystem_error
 #include <ios>            // for ios_base
+#include <system_error>   // for system_error
 #include <vector>         // for vector
 
 namespace adapterremoval {
 
 [[noreturn]] void
-terminate(std::string_view message)
+terminate_on_bug(std::string_view message)
 {
-  log::error()
-    << message << "\n"
-    << "This should not happen! Please file a bug-report at\n"
-    << "    https://github.com/MikkelSchubert/adapterremoval/issues/new\n\n"
-    << "Please specify the AdapterRemoval version (" << program::long_version()
-    << ")\nand if possible describe the steps taken to reproduce this problem.";
+  try {
+    log::error()
+      << message << "\n"
+      << "This should not happen! Please file a bug-report at\n"
+      << "    https://github.com/MikkelSchubert/adapterremoval/issues/new\n\n"
+      << "Please specify the AdapterRemoval version ("
+      << program::long_version()
+      << ")\nand if possible describe the steps taken to reproduce this "
+         "problem.";
+  } catch (...) { // NOLINT(bugprone-empty-catch)
+    // function is called by std::terminate, so cannot rethrow exceptions
+  }
 
   std::abort();
 }
 
-namespace {
+[[noreturn]] void
+terminate_on_failure(std::string_view message)
+{
+  try {
+    log::error()
+      << message
+      << "\nAdapterRemoval did not run to completion; do NOT make use of the "
+         "resulting reads!";
+  } catch (...) { // NOLINT(bugprone-empty-catch)
+    // function is called by std::terminate, so cannot rethrow exceptions
+  }
+
+  std::quick_exit(1);
+}
 
 [[noreturn]] void
 terminate_on_exception()
@@ -39,21 +61,22 @@ terminate_on_exception()
     if (eptr) {
       std::rethrow_exception(eptr);
     } else {
-      terminate("Aborted due to unknown error");
+      terminate_on_bug("Aborted due to unknown error");
     }
+  } catch (const program_failure& ex) {
+    terminate_on_failure(ex.what()); // probably not a bug
+  } catch (const std::filesystem::filesystem_error& ex) {
+    terminate_on_failure(ex.what()); // probably not a bug
+  } catch (const std::system_error& ex) {
+    terminate_on_failure(ex.what()); // may or may not be a bug
   } catch (const std::exception& ex) {
-    log::error()
-      << ex.what()
-      << "\nAdapterRemoval did not run to completion; do NOT make use of the "
-         "resulting reads!";
+    terminate_on_bug(ex.what()); // probably a bug
   } catch (...) {
-    terminate("Caught unknown exception type");
+    terminate_on_bug("Caught unknown exception type");
   }
 
-  std::exit(1);
+  std::abort();
 }
-
-} // namespace
 
 } // namespace adapterremoval
 
@@ -88,6 +111,7 @@ main(int argc, char* argv[])
   auto returncode = 0;
   switch (config.run_type) {
     case ar_command::demultiplex_only:
+      [[fallthrough]];
     case ar_command::trim_adapters: {
       returncode = remove_adapter_sequences(config);
       break;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -7,8 +7,6 @@
 #error "AdapterRemoval cannot be compiled with -ffast-math"
 #endif
 
-#include <string_view> // for string_view
-
 namespace adapterremoval {
 
 class userconfig;
@@ -22,9 +20,5 @@ generate_reports(const userconfig& config);
 // See main_benchmark.cpp
 int
 benchmark(const userconfig& config);
-
-/** Terminate on internal error; prints  */
-[[noreturn]] void
-terminate(std::string_view message);
 
 } // namespace adapterremoval

--- a/tests/unit/main_test.cpp
+++ b/tests/unit/main_test.cpp
@@ -2,22 +2,31 @@
 // SPDX-FileCopyrightText: 2017 Mikkel Schubert <mikkelsch@gmail.com>
 #define CATCH_CONFIG_MAIN
 
+#include "debug.hpp"   // for terminate_on_assert
 #include "errors.hpp"  // for assert_failed
-#include "main.hpp"    // for terminate
 #include "testing.hpp" // for TEST_CASE, REQUIRE, ...
 #include <string_view> // for string_view
 
 namespace adapterremoval {
 
 [[noreturn]] void
-terminate(std::string_view message)
+terminate_on_bug(std::string_view message)
+{
+  throw assert_failed(std::string{ message });
+}
+
+[[noreturn]] void
+terminate_on_failure(std::string_view message)
 {
   throw assert_failed(std::string{ message });
 }
 
 TEST_CASE("terminate")
 {
-  REQUIRE_THROWS_MESSAGE(terminate("foobar"), assert_failed, "foobar");
+  REQUIRE_THROWS_MESSAGE(terminate_on_bug("foobar"), assert_failed, "foobar");
+  REQUIRE_THROWS_MESSAGE(terminate_on_failure("foobar"),
+                         assert_failed,
+                         "foobar");
 }
 
 } // namespace adapterremoval


### PR DESCRIPTION
Reworks exceptions and handling of uncaught exceptions to better distinguish between bugs in the program and failures due to external problems. This is not perfect, but should cause fewer "this is a bug" messages on "normal" errors.

Also made minor improvements to AR_REQUIRE_SINGLE_THREAD macro