### PR TITLE
change fraction and % formatting to take doubles

### DIFF
--- a/src/benchmarking.cpp
+++ b/src/benchmarking.cpp
@@ -199,7 +199,7 @@ benchmarker::summarize(size_t loops) const
 
     if (m_durations.size() > 1) {
       const auto sd = standard_deviation(m_durations);
-      values.at(4) = format_fraction(1e9 * sd, 1e7 * mean);
+      values.at(4) = format_fraction(100.0 * sd, mean);
     }
   }
 

--- a/src/strutils.cpp
+++ b/src/strutils.cpp
@@ -510,13 +510,12 @@ format_rough_number(size_t value, size_t out_digits)
 }
 
 std::string
-format_fraction(uint64_t num, uint64_t denom, size_t precision)
+format_fraction(double num, double denom, size_t precision)
 {
-  if (denom) {
-    const double fraction = static_cast<double>(num) / denom;
-
+  const auto value = num / denom;
+  if (std::isfinite(value)) {
     std::ostringstream ss;
-    ss << std::fixed << std::setprecision(precision) << fraction;
+    ss << std::fixed << std::setprecision(precision) << value;
 
     return ss.str();
   } else {
@@ -525,13 +524,14 @@ format_fraction(uint64_t num, uint64_t denom, size_t precision)
 }
 
 std::string
-format_percentage(uint64_t num, uint64_t denom, size_t precision)
+format_percentage(double num, double denom, size_t precision)
 {
-  if (denom) {
-    return format_fraction(num * 100, denom, precision) + " %";
-  } else {
-    return "NA";
+  auto fraction = format_fraction(num * 100.0, denom, precision);
+  if (fraction != "NA") {
+    fraction.append(" %");
   }
+
+  return fraction;
 }
 
 } // namespace adapterremoval

--- a/src/strutils.hpp
+++ b/src/strutils.hpp
@@ -258,12 +258,12 @@ format_thousand_sep(size_t count);
 std::string
 format_rough_number(size_t value, size_t out_digits = 3);
 
-/** Formats a fraction, returning "NA" if denominator is 0 */
+/** Formats a fraction, returning "NA" if the result is not finite */
 std::string
-format_fraction(uint64_t num, uint64_t denom, size_t precision = 2);
+format_fraction(double num, double denom, size_t precision = 2);
 
-/** Formats percentage and adds trailing " %". Returns "NA" if denom is 0 */
+/** Formats percentage with trailing " %", returning "NA" if not finite */
 std::string
-format_percentage(uint64_t num, uint64_t denom, size_t precision = 1);
+format_percentage(double num, double denom, size_t precision = 1);
 
 } // namespace adapterremoval

--- a/tests/unit/strutils_test.cpp
+++ b/tests/unit/strutils_test.cpp
@@ -445,13 +445,27 @@ TEST_CASE("format_rough_number with no precision")
 
 TEST_CASE("format_fraction")
 {
-  REQUIRE(format_fraction(0, 0) == "NA");
-  REQUIRE(format_fraction(1, 0) == "NA");
-  REQUIRE(format_fraction(55, 300) == "0.18");
-  REQUIRE(format_fraction(55, 300, 0) == "0");
-  REQUIRE(format_fraction(55, 300, 1) == "0.2");
-  REQUIRE(format_fraction(55, 300, 2) == "0.18");
-  REQUIRE(format_fraction(55, 300, 3) == "0.183");
+  constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
+
+  CHECK(format_fraction(0, 0) == "NA");
+  CHECK(format_fraction(1, 0) == "NA");
+  CHECK(format_fraction(nan, 1) == "NA");
+  CHECK(format_fraction(0, nan) == "NA");
+  CHECK(format_fraction(2, 0.5) == "4.00");
+  CHECK(format_fraction(3, 2.0) == "1.50");
+  CHECK(format_fraction(55, 300) == "0.18");
+  CHECK(format_fraction(55, 300, 0) == "0");
+  CHECK(format_fraction(55, 300, 1) == "0.2");
+  CHECK(format_fraction(55, 300, 2) == "0.18");
+  CHECK(format_fraction(55, 300, 3) == "0.183");
+
+  constexpr auto inf = std::numeric_limits<double>::infinity();
+
+  CHECK(format_fraction(1, inf) == "0.00");
+  CHECK(format_fraction(1, -inf) == "-0.00");
+  CHECK(format_fraction(inf, 1) == "NA");
+  CHECK(format_fraction(-inf, 1) == "NA");
+  CHECK(format_fraction(inf, inf) == "NA");
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -459,12 +473,26 @@ TEST_CASE("format_fraction")
 
 TEST_CASE("format_percentage")
 {
-  REQUIRE(format_percentage(0, 0) == "NA");
-  REQUIRE(format_percentage(1, 0) == "NA");
-  REQUIRE(format_percentage(55, 300) == "18.3 %");
-  REQUIRE(format_percentage(55, 300, 0) == "18 %");
-  REQUIRE(format_percentage(55, 300, 1) == "18.3 %");
-  REQUIRE(format_percentage(55, 300, 2) == "18.33 %");
+  constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
+
+  CHECK(format_percentage(0, 0) == "NA");
+  CHECK(format_percentage(1, 0) == "NA");
+  CHECK(format_percentage(nan, 1) == "NA");
+  CHECK(format_percentage(0, nan) == "NA");
+  CHECK(format_percentage(2, 0.5) == "400.0 %");
+  CHECK(format_percentage(3, 2.0) == "150.0 %");
+  CHECK(format_percentage(55, 300) == "18.3 %");
+  CHECK(format_percentage(55, 300, 0) == "18 %");
+  CHECK(format_percentage(55, 300, 1) == "18.3 %");
+  CHECK(format_percentage(55, 300, 2) == "18.33 %");
+
+  constexpr auto inf = std::numeric_limits<double>::infinity();
+
+  CHECK(format_percentage(1, inf) == "0.0 %");
+  CHECK(format_percentage(1, -inf) == "-0.0 %");
+  CHECK(format_percentage(inf, 1) == "NA");
+  CHECK(format_percentage(-inf, 1) == "NA");
+  CHECK(format_percentage(inf, inf) == "NA");
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This makes the functions more flexible, avoids potentially converting arguments twice, while clarifying behavior for non-finite values