### PR TITLE
fix formatting issues for CLI

### DIFF
--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -16,6 +16,7 @@
 #include <string>       // for string
 #include <string_view>  // for string_view
 #include <utility>      // for pair
+#include <vector>       // for vector
 
 namespace adapterremoval::argparse {
 
@@ -417,17 +418,20 @@ argument::keys() const
 std::string
 argument::help() const
 {
-  // Append string representation of current (default) value
   std::ostringstream ss;
   ss << m_help;
 
+  bool has_content = !m_help.empty();
+
   const auto choices = m_sink->choices();
   if (!choices.empty()) {
-    ss << ". Possible values are " << join_text(choices, ", ", ", and ");
+    ss << (has_content ? ". " : "") << "Possible values are "
+       << join_text(choices, ", ", ", and ");
+    has_content = true;
   }
 
   if (m_sink->has_default() && m_help.find("[default:") == std::string::npos) {
-    ss << " [default: " << default_value() << "]";
+    ss << (has_content ? " " : "") << "[default: " << default_value() << "]";
   }
 
   return ss.str();
@@ -849,25 +853,11 @@ double_sink::with_default(double value)
   return *this;
 }
 
-namespace {
-
-std::string
-double_to_string(double value)
-{
-  auto s = stringify(value);
-  s.erase(s.find_last_not_of('0') + 1, std::string::npos);
-  s.erase(s.find_last_not_of('.') + 1, std::string::npos);
-
-  return s;
-}
-
-} // namespace
-
 std::string
 double_sink::default_value() const
 {
   AR_REQUIRE(has_default());
-  return double_to_string(m_default);
+  return concise_stringify(m_default);
 }
 
 double_sink&
@@ -890,7 +880,7 @@ double_sink::with_maximum(double value)
 std::string
 double_sink::value() const
 {
-  return double_to_string(*m_sink);
+  return concise_stringify(*m_sink);
 }
 
 size_t
@@ -901,10 +891,10 @@ double_sink::consume(string_vec_citer start, const string_vec_citer& end)
   const auto value = str_to_double(*start);
   if (value < m_minimum) {
     throw std::invalid_argument("value must be at least " +
-                                double_to_string(m_minimum));
+                                concise_stringify(m_minimum));
   } else if (value > m_maximum) {
     throw std::invalid_argument("value must be at most " +
-                                double_to_string(m_maximum));
+                                concise_stringify(m_maximum));
   }
 
   *m_sink = value;

--- a/src/strutils.cpp
+++ b/src/strutils.cpp
@@ -124,6 +124,22 @@ stringify(double value)
   return os.str();
 }
 
+std::string
+concise_stringify(double value)
+{
+  auto s = stringify(value);
+
+  while (!s.empty() && s.back() == '0') {
+    s.pop_back();
+  }
+
+  if (!s.empty() && s.back() == '.') {
+    s.pop_back();
+  }
+
+  return s;
+}
+
 namespace {
 
 template<typename T>
@@ -328,10 +344,17 @@ cli_formatter::format(const std::string_view value) const
 {
   std::ostringstream lines_out;
 
+  bool first_line = true;
+  bool indent_first = m_indent_first;
   for (const auto& line : split_lines(value)) {
     const auto block = wrap_text(line, m_columns, m_ljust);
+    if (!first_line) {
+      lines_out << "\n";
+    }
 
-    lines_out << join_text(indent(block, m_indentation, m_indent_first), "\n");
+    lines_out << join_text(indent(block, m_indentation, indent_first), "\n");
+    indent_first = true;
+    first_line = false;
   }
 
   return lines_out.str();

--- a/src/strutils.hpp
+++ b/src/strutils.hpp
@@ -55,6 +55,10 @@ stringify(unsigned long long value);
 std::string
 stringify(double value);
 
+/** Equivalent to stringify(double), but trims trailing zeroes/decimal point */
+std::string
+concise_stringify(double value);
+
 /* Deleted to prevent ambiguity */
 std::string
 stringify(bool value) = delete;

--- a/tests/unit/argparse_test.cpp
+++ b/tests/unit/argparse_test.cpp
@@ -815,6 +815,58 @@ TEST_CASE("help with choices", "[argparse::argument]")
   }
 }
 
+TEST_CASE("help with different segments", "[argparse::argument]")
+{
+  argparse::argument arg("--12345", "67890");
+
+  SECTION("help only")
+  {
+    arg.help("gibberish");
+    REQUIRE(arg.help() == "gibberish");
+  }
+
+  SECTION("choices only")
+  {
+    arg.bind_str(nullptr).with_choices({ "foo", "bar" });
+    REQUIRE(arg.help() == "Possible values are foo, and bar");
+  }
+
+  SECTION("help and choices")
+  {
+    arg.help("gibberish").bind_str(nullptr).with_choices({ "foo", "bar" });
+    REQUIRE(arg.help() == "gibberish. Possible values are foo, and bar");
+  }
+
+  SECTION("default only")
+  {
+    arg.bind_str(nullptr).with_default("value");
+    REQUIRE(arg.help() == "[default: value]");
+  }
+
+  SECTION("help and default")
+  {
+    arg.help("gibberish").bind_str(nullptr).with_default("value");
+    REQUIRE(arg.help() == "gibberish [default: value]");
+  }
+
+  SECTION("choices and default")
+  {
+    arg.bind_str(nullptr).with_choices({ "foo", "bar" }).with_default("foo");
+    REQUIRE(arg.help() == "Possible values are foo, and bar [default: foo]");
+  }
+
+  SECTION("help, choices and default")
+  {
+    arg.help("gibberish")
+      .bind_str(nullptr)
+      .with_choices({ "foo", "bar" })
+      .with_default("foo");
+
+    REQUIRE(arg.help() ==
+            "gibberish. Possible values are foo, and bar [default: foo]");
+  }
+}
+
 TEST_CASE("deprecated argument", "[argparse::argument]")
 {
   argparse::argument arg("--12345");
@@ -1690,6 +1742,64 @@ TEST_CASE("help with lower and upper bound of values", "[argparse::parser]")
           "   -v, --version        Print the version string\n"
           "   --licenses           Print licenses for this software\n\n"
           "   --test <X> <X> [X]   Help text\n");
+}
+
+TEST_CASE("line-breaks in preamble are preserved", "[argparse]")
+{
+  log::log_capture ss;
+  argparse::parser p;
+  p.set_name("My App");
+  p.set_version("1234");
+  p.set_preamble(
+    "A long help preamble that exceeds the limit of 60 characters by "
+    "some amount.\n\nAdditionally, it contains newlines in order to "
+    "test formatting of those");
+
+  p.set_terminal_width(60);
+  p.print_help();
+
+  REQUIRE(ss.str() ==
+          "My App v1234\n\n"
+          "A long help preamble that exceeds the limit of 60 characters\n"
+          "by some amount.\n\n"
+          "Additionally, it contains newlines in order to test\n"
+          "formatting of those\n\n"
+          "OPTIONS:\n"
+          "   -h, --help      Display this message\n"
+          "   -v, --version   Print the version string\n"
+          "   --licenses      Print licenses for this software\n\n");
+}
+
+TEST_CASE("line-breaks in help text are preserved", "[argparse]")
+{
+  uint32_t sink = 0;
+  log::log_capture ss;
+  argparse::parser p;
+  p.set_name("My App");
+  p.set_version("1234");
+  p.set_preamble("basic help");
+  p.add("--test", "META")
+    .help("A long help message that exceeds the limit of 60 characters by "
+          "some amount.\n\nAdditionally, it contains newlines in order to "
+          "test formatting of those")
+    .bind_u32(&sink)
+    .with_default(1234);
+
+  p.set_terminal_width(60);
+  p.print_help();
+
+  REQUIRE(ss.str() ==
+          "My App v1234\n\n"
+          "basic help\n\n"
+          "OPTIONS:\n"
+          "   -h, --help      Display this message\n"
+          "   -v, --version   Print the version string\n"
+          "   --licenses      Print licenses for this software\n\n"
+          "   --test <META>   A long help message that exceeds the\n"
+          "                   limit of 60 characters by some amount.\n\n"
+          "                   Additionally, it contains newlines in\n"
+          "                   order to test formatting of those\n"
+          "                   [default: 1234]\n");
 }
 
 TEST_CASE("parse_result to string", "[argparse]")

--- a/tests/unit/strutils_test.cpp
+++ b/tests/unit/strutils_test.cpp
@@ -554,7 +554,7 @@ TEST_CASE("trim_ascii_whitespace")
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// Tests for 'stringify'
+// Tests for 'stringify' functions
 
 TEST_CASE("stringify")
 {
@@ -597,6 +597,37 @@ TEST_CASE("stringify")
   CHECK(stringify(std::numeric_limits<double>::infinity()) == "inf");
   CHECK(stringify(-std::numeric_limits<double>::infinity()) == "-inf");
   CHECK(stringify(std::numeric_limits<double>::quiet_NaN()) == "nan");
+}
+
+TEST_CASE("concise_stringify")
+{
+  using limits = std::numeric_limits<double>;
+
+  CHECK(concise_stringify(0.0) == "0");
+  CHECK(concise_stringify(1.0) == "1");
+  CHECK(concise_stringify(0.5) == "0.5");
+  CHECK(concise_stringify(1.234) == "1.234");
+  CHECK(concise_stringify(-0.5) == "-0.5");
+
+  CHECK(concise_stringify(double{}) == "0");
+  CHECK(concise_stringify(limits::min()) == "0");
+  CHECK(concise_stringify(limits::lowest()) ==
+        "-179769313486231570814527423731704356798070567525844996598917476803157"
+        "2607800285387605895586327668781715404589535143824642343213268894641827"
+        "6846754670353751698604991057655128207624549009038932894407586850845513"
+        "3942304583236903222948165808559332123348274797826204144723168738177180"
+        "919299881250404026184124858368");
+  CHECK(concise_stringify(limits::max()) ==
+        "1797693134862315708145274237317043567980705675258449965989174768031572"
+        "6078002853876058955863276687817154045895351438246423432132688946418276"
+        "8467546703537516986049910576551282076245490090389328944075868508455133"
+        "9423045832369032229481658085593321233482747978262041447231687381771809"
+        "19299881250404026184124858368");
+  CHECK(concise_stringify(3.141592653589) == "3.141593");
+  CHECK(concise_stringify(limits::epsilon()) == "0");
+  CHECK(concise_stringify(limits::infinity()) == "inf");
+  CHECK(concise_stringify(-limits::infinity()) == "-inf");
+  CHECK(concise_stringify(limits::quiet_NaN()) == "nan");
 }
 
 } // namespace adapterremoval


### PR DESCRIPTION
- Fix missing newlines between paragraphs in help text
- Fix placement of whitespace/dots between sections of help text
- Make trailing zero stripping robust to changes to `stringify` output
- Rename `double_to_string` to `concise_stringify`, move it to strutils, and add tests