### PR TITLE
update sphinx config for RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,9 +4,13 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
 
 sphinx:
   configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements-rtd.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,10 +36,6 @@ smartquotes = False
 
 if os.environ.get("READTHEDOCS") == "True":
     # https://sphinx-rtd-theme.readthedocs.io/
-    extensions = [
-        "sphinx_rtd_theme",
-    ]
-
     html_theme = "sphinx_rtd_theme"
 else:
     # http://alabaster.readthedocs.io/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,52 +8,50 @@
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+import os
 
 # General information about the project.
-project = "AdapterRemoval3"
-copyright = "2026, Mikkel Schubert; Stinus Lindgreen"
+project = "AdapterRemoval"
+copyright = "%Y, Mikkel Schubert; Stinus Lindgreen"
 author = "Mikkel Schubert; Stinus Lindgreen"
 
-# The version info for the project you're documenting, acts as replacement for
-# |version| and |release|, also used in various other places throughout the
-# built documents.
-#
-# The short X.Y version.
+# The short X.Y version (`|version|`)
 version = "3.0"
-# The full version, including alpha/beta/rc tags.
+# The full version, including alpha/beta/rc tags (`|release|`)
 release = "3.0.0"
 
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = []
-
-templates_path = ["_templates"]
 source_suffix = ".rst"
 master_doc = "index"
 language = "en"
 
-# The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "sphinx"
 # Prevent conversion of -- to emdashes
 smartquotes = False
 
-# -- Options for HTML output ----------------------------------------------
 
-html_theme = "alabaster"
-html_static_path = []
+# -- Themes ----------------------------------------------
 
-# Custom sidebar templates, must be a dictionary that maps document names
-# to template names.
-#
-# This is required for the alabaster theme
-# refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {
-    "**": [
-        "about.html",
-        "navigation.html",
-        "relations.html",  # needs 'show_related': True theme option to display
-        "searchbox.html",
+if os.environ.get("READTHEDOCS") == "True":
+    # https://sphinx-rtd-theme.readthedocs.io/
+    extensions = [
+        "sphinx_rtd_theme",
     ]
-}
+
+    html_theme = "sphinx_rtd_theme"
+else:
+    # http://alabaster.readthedocs.io/
+    html_theme = "alabaster"
+
+    # This is required for the alabaster theme
+    html_sidebars = {
+        "**": [
+            "about.html",
+            "searchfield.html",
+            "navigation.html",
+            "relations.html",
+            "donate.html",
+        ]
+    }

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -49,7 +49,7 @@ if sphinx_build.found()
                 '-c', '@0@ -M man @1@ @PRIVATE_DIR@ -n -q -E -d @PRIVATE_DIR@ && mv -v @2@ @OUTPUT@'.format(
                     sphinx_build.full_path(),
                     '@CURRENT_SOURCE_DIR@',
-                    '@PRIVATE_DIR@' / 'man' / (meson.project_name() + '.1'),
+                    '@PRIVATE_DIR@' / 'man' / 'adapterremoval.1',
                 ),
             ],
             install: not get_option('manpage').disabled(),

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -1,0 +1,3 @@
+# Requirements for ReadTheDocs
+sphinx==9.1.0
+sphinx_rtd_theme==3.1.0


### PR DESCRIPTION
Use read-the-docs theme when building on that service, built-in theme 'alabaster' otherwise. Also clean up config, automate copyright year, and use "AdapterRemoval" as name to match everything else