### PR TITLE
add -Wextra-semi

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,6 +69,8 @@ add_project_arguments(
         '-Wswitch-default', # Require a default: statement in a switch, to catch corruption
         '-Wundef', # Undefined variables used in #if pragmas
         '-Wnrvo',
+        # Extraneous semicolons may cause errors on old compilers due to -pedantic-errors
+        '-Wextra-semi',
     ),
     language: 'cpp',
 )

--- a/src/adapter_detector.hpp
+++ b/src/adapter_detector.hpp
@@ -20,7 +20,7 @@ namespace simd {
 
 enum class instruction_set;
 
-};
+}
 
 //! Minimum overlap required for adapter fragments
 inline constexpr size_t ADAPTER_DETECT_MIN_OVERLAP = 8;

--- a/src/argparse.hpp
+++ b/src/argparse.hpp
@@ -305,13 +305,13 @@ public:
                          const string_vec_citer& end) = 0;
 
   /** Returns the list of valid choices, if any, formatted as strings */
-  [[nodiscard]] virtual string_vec choices() const { return {}; };
+  [[nodiscard]] virtual string_vec choices() const { return {}; }
 
   /** Indicates the minimum number of values taken by this sink */
-  [[nodiscard]] size_t min_values() const { return m_min_values; };
+  [[nodiscard]] size_t min_values() const { return m_min_values; }
 
   /** Indicates the maximum number of values taken by this sink */
-  [[nodiscard]] size_t max_values() const { return m_max_values; };
+  [[nodiscard]] size_t max_values() const { return m_max_values; }
 
   /** Sets pre-processor function used before validating input  */
   sink& with_preprocessor(preprocess_func func)

--- a/src/errors.hpp
+++ b/src/errors.hpp
@@ -49,7 +49,7 @@ protected:
                                                                                \
   protected:                                                                   \
     [[nodiscard]] std::string_view kind() const override { return #name; }     \
-  };
+  }
 
 /** Represents errors during basic IO. */
 class io_error : public program_failure

--- a/src/linereader_joined.hpp
+++ b/src/linereader_joined.hpp
@@ -25,7 +25,7 @@ public:
   void inc_position(size_t n = 1);
 
   /** Returns the position across all files. Should not be used in logs */
-  [[nodiscard]] size_t position() const noexcept { return m_position; };
+  [[nodiscard]] size_t position() const noexcept { return m_position; }
 
   /** List filenames covered by an inclusive range of positions */
   [[nodiscard]] std::string filenames(size_t start, size_t end) const;

--- a/src/managed_io.cpp
+++ b/src/managed_io.cpp
@@ -286,7 +286,7 @@ public:
       io_manager::remove(m_writer);
       io_manager::open(m_writer);
     }
-  };
+  }
 
   ~writer_lock()
   {

--- a/tests/unit/alignment_test.cpp
+++ b/tests/unit/alignment_test.cpp
@@ -47,11 +47,11 @@ struct ALN
     info.m_adapter_id = 0;
   }
 
-  TEST_ALIGNMENT_SETTER(int, offset);
-  TEST_ALIGNMENT_SETTER(size_t, length);
-  TEST_ALIGNMENT_SETTER(size_t, n_mismatches);
-  TEST_ALIGNMENT_SETTER(size_t, n_ambiguous);
-  TEST_ALIGNMENT_SETTER(int, adapter_id);
+  TEST_ALIGNMENT_SETTER(int, offset)
+  TEST_ALIGNMENT_SETTER(size_t, length)
+  TEST_ALIGNMENT_SETTER(size_t, n_mismatches)
+  TEST_ALIGNMENT_SETTER(size_t, n_ambiguous)
+  TEST_ALIGNMENT_SETTER(int, adapter_id)
 
   ALN& is_good()
   {


### PR DESCRIPTION
This helps catch extranous semicolons, that may cause build-errors on with older compilers due to -pedantic-errors