### PR TITLE
implement specialized quality converter functions

### DIFF
--- a/src/debug.hpp
+++ b/src/debug.hpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2015 Mikkel Schubert <mikkelsch@gmail.com>
 #pragma once
 
+#include "pragmas.hpp" // for AR_LIKELY
 #include <mutex>       // for recursive_mutex
 #include <string_view> // for string_view
 
@@ -26,18 +27,6 @@ terminate_on_assert(std::string_view funcname,
                     unsigned lineno,
                     std::string_view test,
                     std::string_view msg);
-
-#ifdef __has_builtin
-#if __has_builtin(__builtin_expect)
-#define AR_LIKELY(condition) __builtin_expect(static_cast<bool>(condition), 1)
-#define AR_UNLIKELY(condition) __builtin_expect(static_cast<bool>(condition), 0)
-#endif
-#endif
-
-#ifndef AR_LIKELY
-#define AR_LIKELY(condition) (!!(condition))
-#define AR_UNLIKELY(condition) (!!(condition))
-#endif
 
 /** Custom assert which prints various information on failure; always enabled */
 #define AR_REQUIRE_2_(test, msg)                                               \

--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -6,6 +6,7 @@
 #include "errors.hpp"     // for fastq_error
 #include "fastq_enc.hpp"  // for fastq_encoding
 #include "linereader.hpp" // for line_reader_base
+#include "pragmas.hpp"    // for AR_LIKELY
 #include "strutils.hpp"   // for log_escape
 #include <algorithm>      // for reverse, count, max, min
 #include <array>          // for array

--- a/src/fastq_enc.cpp
+++ b/src/fastq_enc.cpp
@@ -4,12 +4,14 @@
 #include "fastq_enc.hpp" // header
 #include "debug.hpp"     // for AR_FAIL, AR_REQUIRE
 #include "errors.hpp"    // for fastq_error
+#include "pragmas.hpp"   // for AR_UNLIKELY
 #include "strutils.hpp"  // for shell_escape
 #include <algorithm>     // for min, max
 #include <array>         // for array
 #include <cmath>         // for log10, pow, round
 #include <sstream>       // for ostringstream
 #include <string>        // for string
+#include <string_view>   // for string_view
 
 namespace adapterremoval {
 
@@ -291,6 +293,58 @@ constexpr auto NUCLEOTIDES_LUT_URACILS = build_lookup_table(false, true);
 constexpr auto NUCLEOTIDES_LUT_DEGENERATE = build_lookup_table(true, false);
 constexpr auto NUCLEOTIDES_LUT_BOTH = build_lookup_table(true, true);
 
+void
+validate_sam(std::string_view qualities)
+{
+  AR_UNROLL(8)
+  for (const auto quality : qualities) {
+    if (AR_UNLIKELY(quality < PHRED_OFFSET_MIN || quality > PHRED_OFFSET_MAX)) {
+      throw_invalid_score(quality_encoding::sam, quality);
+    }
+  }
+}
+
+void
+validate_phred_33(std::string_view qualities)
+{
+  AR_UNROLL(8)
+  for (const auto quality : qualities) {
+    if (AR_UNLIKELY(quality < PHRED_33_OFFSET_MIN ||
+                    quality > PHRED_33_OFFSET_MAX)) {
+      throw_invalid_score(quality_encoding::phred_33, quality);
+    }
+  }
+}
+
+void
+convert_phred_64_to_33(std::string& qualities)
+{
+  AR_UNROLL(8)
+  for (auto& quality : qualities) {
+    if (AR_UNLIKELY(quality < PHRED_64_OFFSET_MIN ||
+                    quality > PHRED_64_OFFSET_MAX)) {
+      throw_invalid_score(quality_encoding::phred_64, quality);
+    }
+
+    // Convert Phred+64 to Phred+33
+    quality += PHRED_33_OFFSET_MIN - PHRED_64_OFFSET_MIN;
+  }
+}
+
+void
+convert_solexa_to_phred_33(std::string& qualities)
+{
+  AR_UNROLL(8)
+  for (auto& quality : qualities) {
+    const char current = quality;
+
+    quality = g_solexa_to_phred33.at(static_cast<unsigned char>(quality));
+    if (AR_UNLIKELY(quality == '\0')) {
+      throw_invalid_score(quality_encoding::solexa, current);
+    }
+  }
+}
+
 } // namespace
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -298,8 +352,6 @@ constexpr auto NUCLEOTIDES_LUT_BOTH = build_lookup_table(true, true);
 fastq_encoding::fastq_encoding(quality_encoding encoding,
                                degenerate_encoding degenerate,
                                uracil_encoding uracils) noexcept
-  : m_encoding(encoding)
-
 {
   if (degenerate == degenerate_encoding::reject &&
       uracils == uracil_encoding::reject) {
@@ -319,25 +371,17 @@ fastq_encoding::fastq_encoding(quality_encoding encoding,
 
   switch (encoding) {
     case quality_encoding::phred_33:
-      m_offset_min = PHRED_33_OFFSET_MIN;
-      m_offset_max = PHRED_33_OFFSET_MAX;
+      m_validate_quality_func = validate_phred_33;
       break;
-
     case quality_encoding::phred_64:
-      m_offset_min = PHRED_64_OFFSET_MIN;
-      m_offset_max = PHRED_64_OFFSET_MAX;
+      m_convert_quality_func = convert_phred_64_to_33;
       break;
-
     case quality_encoding::solexa:
-      m_offset_min = SOLEXA_OFFSET_MIN;
-      m_offset_max = SOLEXA_OFFSET_MAX;
+      m_convert_quality_func = convert_solexa_to_phred_33;
       break;
-
     case quality_encoding::sam:
-      m_offset_min = PHRED_OFFSET_MIN;
-      m_offset_max = PHRED_OFFSET_MAX;
+      m_validate_quality_func = validate_sam;
       break;
-
     default:
       AR_FAIL("unknown quality encoding");
   }
@@ -346,6 +390,7 @@ fastq_encoding::fastq_encoding(quality_encoding encoding,
 void
 fastq_encoding::process_nucleotides(std::string& sequence) const
 {
+  AR_UNROLL(8)
   for (char& nuc : sequence) {
     const char original = nuc;
     nuc = m_nucleotides_lut[static_cast<unsigned char>(nuc)];
@@ -358,25 +403,11 @@ fastq_encoding::process_nucleotides(std::string& sequence) const
 void
 fastq_encoding::process_qualities(std::string& qualities) const
 {
-  if (m_encoding == quality_encoding::solexa) {
-    for (auto& quality : qualities) {
-      const char current = quality;
-      const auto idx = static_cast<unsigned char>(quality);
-
-      quality = g_solexa_to_phred33.at(idx);
-      if (quality == '\0') {
-        throw_invalid_score(m_encoding, current);
-      }
-    }
+  if (m_validate_quality_func) {
+    m_validate_quality_func(qualities);
   } else {
-    for (auto& quality : qualities) {
-      if (quality < m_offset_min || quality > m_offset_max) {
-        throw_invalid_score(m_encoding, quality);
-      }
-
-      // Convert Phred+64 to Phred+33 if needed
-      quality -= m_offset_min - PHRED_33_OFFSET_MIN;
-    }
+    AR_REQUIRE(m_convert_quality_func);
+    m_convert_quality_func(qualities);
   }
 }
 

--- a/src/fastq_enc.hpp
+++ b/src/fastq_enc.hpp
@@ -3,9 +3,10 @@
 // SPDX-FileCopyrightText: 2014 Mikkel Schubert <mikkelsch@gmail.com>
 #pragma once
 
-#include <array>   // for array
-#include <cstddef> // for size_t
-#include <string>  // for string
+#include <array>      // for array
+#include <cstddef>    // for size_t
+#include <functional> // for function
+#include <string>     // for string
 
 namespace adapterremoval {
 
@@ -60,6 +61,8 @@ public:
     degenerate_encoding degenerate = degenerate_encoding::reject,
     uracil_encoding uracils = uracil_encoding::reject) noexcept;
 
+  ~fastq_encoding() = default;
+
   /** Validates/normalizes a string of nucleotides in-place. */
   void process_nucleotides(std::string& sequence) const;
 
@@ -75,15 +78,18 @@ public:
   /** Converts an error probability (>= 0) to a Phred+33 encoded score */
   static char p_to_phred_33(double p);
 
+  fastq_encoding(const fastq_encoding&) = default;
+  fastq_encoding(fastq_encoding&&) = default;
+  fastq_encoding& operator=(const fastq_encoding&) = default;
+  fastq_encoding& operator=(fastq_encoding&&) = default;
+
 private:
   //! Lookup table for conversion/validation of nucleotides
   std::array<char, 256>::const_pointer m_nucleotides_lut{ nullptr };
-  //! Quality score encoding expected when decoding data
-  quality_encoding m_encoding;
-  //! Offset of the lowest ASCII value used by the given encoding
-  char m_offset_min{};
-  //! Offset of the maximum ASCII value used by the given encoding
-  char m_offset_max{};
+  //! Function for converting from selected quality encoding
+  std::function<void(std::string&)> m_convert_quality_func{ nullptr };
+  //! Function for validating the selected quality encoding
+  std::function<void(std::string_view)> m_validate_quality_func{ nullptr };
 };
 
 inline const fastq_encoding FASTQ_ENCODING_33{ quality_encoding::phred_33 };

--- a/src/pragmas.hpp
+++ b/src/pragmas.hpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Mikkel Schubert <mikkelsch@gmail.com>
+#pragma once
+
+#ifdef __has_builtin
+#if __has_builtin(__builtin_expect)
+//! Indicate that a condition is likely to happen
+#define AR_LIKELY(condition) __builtin_expect(static_cast<bool>(condition), 1)
+//! Indicate that a condition is unlikely to happen
+#define AR_UNLIKELY(condition) __builtin_expect(static_cast<bool>(condition), 0)
+#endif
+#endif
+
+#ifndef AR_LIKELY
+#define AR_LIKELY(condition) (!!(condition))
+#define AR_UNLIKELY(condition) (!!(condition))
+#endif
+
+//! Helper macro to allow application of pragmas
+#define _APPLY_PRAGMA(x) _Pragma(#x)
+
+//! Unroll a loop n times
+#ifdef __clang__
+#define AR_UNROLL(n) _APPLY_PRAGMA(unroll n)
+#elif defined(__GNUC__)
+#define AR_UNROLL(n) _APPLY_PRAGMA(GCC unroll n)
+#else
+#define AR_UNROLL(n) // no-op fallback
+#endif


### PR DESCRIPTION
Along with loop unrolling, this reduces pre-processing time by 1/3.

As part of this, pragmas and intrinsics are moved from 'debug.hpp' to their own header