### PR TITLE
optimizations to SIMD-based alignment

### DIFF
--- a/src/simd.cpp
+++ b/src/simd.cpp
@@ -78,7 +78,7 @@ padding(instruction_set value)
 #endif
     case instruction_set::avx512:
 #if HAVE_AVX512
-      return 0;
+      return 63;
 #else
       AR_FAIL("AVX512 not supported!");
 #endif

--- a/src/simd_avx2.cpp
+++ b/src/simd_avx2.cpp
@@ -37,26 +37,38 @@ compare_subsequences_avx2(size_t& n_mismatches,
     const auto s2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(seq_2));
 
     // Sets 0xFF for every byte where one or both nts is N
-    const __m256i ns_mask = _mm256_or_si256(_mm256_cmpeq_epi8(s1, n_mask),
-                                            _mm256_cmpeq_epi8(s2, n_mask));
+    const auto ns_mask = _mm256_or_si256(_mm256_cmpeq_epi8(s1, n_mask),
+                                         _mm256_cmpeq_epi8(s2, n_mask));
+    const auto n_count = count_masked_avx2(ns_mask);
 
-    // Sets 0xFF for every byte where bytes are equal or N
-    const __m256i eq_mask = _mm256_or_si256(_mm256_cmpeq_epi8(s1, s2), ns_mask);
+    if (n_count) {
+      // Sets 0xFF for every byte where bytes are equal or N
+      const __m256i eq_mask =
+        _mm256_or_si256(_mm256_cmpeq_epi8(s1, s2), ns_mask);
 
-    n_mismatches += 32 - count_masked_avx2(eq_mask);
-    if ((2 * n_mismatches) + n_ambiguous > max_penalty) {
-      return false;
+      // Early termination is almost always due to mismatches, so updating the
+      // number of Ns after the penalty check saves time in the common case.
+      n_mismatches += 32 - count_masked_avx2(eq_mask);
+      if ((2 * n_mismatches) + n_ambiguous > max_penalty) {
+        return false;
+      }
+
+      const size_t unpadded_length = std::min<size_t>(32, length);
+      n_ambiguous += n_count - (32 - unpadded_length);
+
+      seq_1 += unpadded_length;
+      seq_2 += unpadded_length;
+      length -= unpadded_length;
+    } else {
+      n_mismatches += 32 - count_masked_avx2(_mm256_cmpeq_epi8(s1, s2));
+      if ((2 * n_mismatches) + n_ambiguous > max_penalty) {
+        return false;
+      }
+
+      seq_1 += 32;
+      seq_2 += 32;
+      length -= 32;
     }
-
-    const size_t unpadded_length = std::min<size_t>(32, length);
-
-    // Early termination is almost always due to mismatches, so updating the
-    // number of Ns after the above check saves time in the common case.
-    n_ambiguous += count_masked_avx2(ns_mask) - (32 - unpadded_length);
-
-    seq_1 += 32;
-    seq_2 += 32;
-    length -= unpadded_length;
   }
 
   return (2 * n_mismatches) + n_ambiguous <= max_penalty;

--- a/src/simd_avx512bw.cpp
+++ b/src/simd_avx512bw.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2024 Mikkel Schubert <mikkelsch@gmail.com>
+#include "debug.hpp"   // for AR_UNLIKELY
 #include "simd.hpp"    // declarations
 #include <bitset>      // for bitset
 #include <cstddef>     // for size_t
@@ -31,39 +32,37 @@ compare_subsequences_avx512(size_t& n_mismatches,
   const auto n_mask = _mm512_set1_epi8('N');
 
   while (length) {
-    __m512i s1;
-    __m512i s2;
+    const __m512i s1 = _mm512_loadu_epi8(seq_1);
+    const __m512i s2 = _mm512_loadu_epi8(seq_2);
 
-    if (length < 64) {
-      const auto mask = 0xFFFFFFFFFFFFFFFFLLU >> (64 - length);
-      s1 = _mm512_maskz_loadu_epi8(mask, seq_1);
-      s2 = _mm512_maskz_loadu_epi8(mask, seq_2);
-
-      length = 0;
-    } else {
-      s1 = _mm512_loadu_epi8(seq_1);
-      s2 = _mm512_loadu_epi8(seq_2);
-
-      seq_1 += 64;
-      seq_2 += 64;
-      length -= 64;
-    }
-
-    // Sets 0xFF for every bit where one or both nucleotides is N
+    // Sets 1 for every bit where one or both nucleotides is N
     const auto ns_mask =
       _mm512_cmpeq_epu8_mask(s1, n_mask) | _mm512_cmpeq_epu8_mask(s2, n_mask);
 
-    // Sets 0xFF for every bit where nucleotides are equal or N
-    const auto eq_mask = _mm512_cmpeq_epu8_mask(s1, s2) | ns_mask;
+    // Sets 1 for every bit where nucleotides are equal or N
+    n_mismatches +=
+      count_masked_avx512(~(_mm512_cmpeq_epu8_mask(s1, s2) | ns_mask));
 
-    n_mismatches += 64 - count_masked_avx512(eq_mask);
+    // Early termination is almost always due to mismatches, so updating the
+    // number of Ns after the penalty check saves time in the common case.
     if ((2 * n_mismatches) + n_ambiguous > max_penalty) {
       return false;
     }
 
-    // Early termination is almost always due to mismatches, so updating the
-    // number of Ns after the above check saves time in the common case.
-    n_ambiguous += count_masked_avx512(ns_mask);
+    if (ns_mask) {
+      // Either read contains an 'N' or we've reached the padding
+      const size_t unpadded_length = std::min<size_t>(64, length);
+
+      n_ambiguous += count_masked_avx512(ns_mask) - (64 - unpadded_length);
+
+      seq_1 += unpadded_length;
+      seq_2 += unpadded_length;
+      length -= unpadded_length;
+    } else {
+      seq_1 += 64;
+      seq_2 += 64;
+      length -= 64;
+    }
   }
 
   return (2 * n_mismatches) + n_ambiguous <= max_penalty;

--- a/src/simd_none.cpp
+++ b/src/simd_none.cpp
@@ -1,16 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2022 Mikkel Schubert <mikkelsch@gmail.com>
-#include "simd.hpp" // for size_t, compare_subsequences_std
-#include <cstddef>  // for size_t
+#include "pragmas.hpp" // for AR_UNROLL
+#include "simd.hpp"    // for size_t, compare_subsequences_std
+#include <cstddef>     // for size_t
 
 namespace adapterremoval::simd {
-
-namespace {
-
-//! Number of nucleotides to compare per (unrolled) loop
-constexpr size_t LOOP_COUNT = 8;
-
-} // namespace
 
 bool
 compare_subsequences_none(size_t& n_mismatches,
@@ -24,26 +18,7 @@ compare_subsequences_none(size_t& n_mismatches,
   size_t tmp_mismatches = n_mismatches;
   size_t tmp_ambiguous = n_ambiguous;
 
-  while (length >= LOOP_COUNT) {
-    // A constant loop count enables loop-unrolling for increased throughput
-    for (size_t i = 0; i < LOOP_COUNT; ++i) {
-      const char nt_1 = *seq_1++;
-      const char nt_2 = *seq_2++;
-
-      if (nt_1 == 'N' || nt_2 == 'N') {
-        tmp_ambiguous++;
-      } else if (nt_1 != nt_2) {
-        tmp_mismatches++;
-      }
-    }
-
-    if ((2 * tmp_mismatches) + tmp_ambiguous > max_penalty) {
-      return false;
-    }
-
-    length -= LOOP_COUNT;
-  }
-
+  AR_UNROLL(8)
   for (; length; --length) {
     const char nt_1 = *seq_1++;
     const char nt_2 = *seq_2++;

--- a/src/simd_sse2.cpp
+++ b/src/simd_sse2.cpp
@@ -44,20 +44,28 @@ compare_subsequences_sse2(size_t& n_mismatches,
     const auto eq_mask = _mm_or_si128(_mm_cmpeq_epi8(s1, s2), ns_mask);
 
     n_mismatches += 16 - count_masked_sse2(eq_mask);
+    // Early termination is almost always due to mismatches, so updating the
+    // number of Ns after the penalty check saves time in the common case.
     if ((2 * n_mismatches) + n_ambiguous > max_penalty) {
       return false;
     }
 
-    // Fragment length without 'N' padding
-    const size_t unpadded_length = std::min<size_t>(16, length);
+    const auto ns_count = count_masked_sse2(ns_mask);
 
-    // Early termination is almost always due to mismatches, so updating the
-    // number of Ns after the above check saves time in the common case.
-    n_ambiguous += count_masked_sse2(ns_mask) - (16 - unpadded_length);
+    if (ns_count) {
+      // Fragment length without 'N' padding
+      const size_t unpadded_length = std::min<size_t>(16, length);
 
-    seq_1 += 16;
-    seq_2 += 16;
-    length -= unpadded_length;
+      n_ambiguous += ns_count - (16 - unpadded_length);
+
+      seq_1 += unpadded_length;
+      seq_2 += unpadded_length;
+      length -= unpadded_length;
+    } else {
+      seq_1 += 16;
+      seq_2 += 16;
+      length -= 16;
+    }
   }
 
   return (2 * n_mismatches) + n_ambiguous <= max_penalty;


### PR DESCRIPTION
- Make AVX512 use padded alignments instead of masked loads
- Branch based on the presence of Ns for SSE2, AVX2, AVX512
- Use automatic loop unrolling for non-vectorized algorithm

This results in 20-30% higher throughput for the SIMD algorithms for typical data with few Ns.