### PR TITLE
fix build in version not following semver spec

### DIFF
--- a/src/version.cpp.in
+++ b/src/version.cpp.in
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2025 Mikkel Schubert <mikkelsch@gmail.com>
-#include "version.hpp"  // declarations
-#include <string_view>  // for string_view
+#include "version.hpp" // declarations
+#include <string_view> // for string_view
 
 namespace adapterremoval::program {
+
+constexpr bool HAS_BUILD = std::string_view{ "PLACEHOLDER" } != "unknown";
 
 std::string_view
 name()
@@ -14,7 +16,11 @@ name()
 std::string_view
 long_version()
 {
-  return PROJECT_VERSION "-PLACEHOLDER";
+  if (HAS_BUILD) {
+    return PROJECT_VERSION "+PLACEHOLDER";
+  }
+
+  return PROJECT_VERSION;
 }
 
 std::string_view
@@ -38,7 +44,11 @@ short_name()
 std::string_view
 long_name()
 {
-  return PROJECT_NAME " " PROJECT_VERSION "-PLACEHOLDER";
+  if (HAS_BUILD) {
+    return PROJECT_NAME " " PROJECT_VERSION "+PLACEHOLDER";
+  }
+
+  return PROJECT_NAME " " PROJECT_VERSION;
 }
 
 } // namespace adapterremoval::program


### PR DESCRIPTION
- build is now appended to version as `+build`, rather than `-build`
- the fallback string ("unknown") is no longer added to non-git builds