### PR TITLE
use `_Exit` instead of `quick_exit`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
 #include "reports.hpp"    // for print_terminal_postamble, print_terminal_...
 #include "userconfig.hpp" // for ar_command, userconfig, ar_command::demul...
 #include "version.hpp"    // for version
-#include <cstdlib>        // for abort, size_t, quick_exit
+#include <cstdlib>        // for abort, size_t, _Exit
 #include <exception>      // for set_terminate
 #include <filesystem>     // for filesystem_error
 #include <ios>            // for ios_base
@@ -51,7 +51,8 @@ terminate_on_failure(std::string_view message)
     // function is called by std::terminate, so cannot rethrow exceptions
   }
 
-  std::quick_exit(1);
+  // used since not all targets have `quick_exit` and no handlers are registered
+  std::_Exit(1);
 }
 
 [[noreturn]] void


### PR DESCRIPTION
Not all target platforms have `_Exit` (e.g. old OSX), and no `at_quick_exit` handlers are used